### PR TITLE
fix glow stop once refreshed

### DIFF
--- a/frontend/src/components/AnnotationManagement.tsx
+++ b/frontend/src/components/AnnotationManagement.tsx
@@ -288,7 +288,10 @@ export const AnnotationManagement: FC = () => {
               )}{' '}
               <button
                 className={cx('getelement', settingChanged ? 'setting-changed' : '')}
-                onClick={refetchElement}
+                onClick={() => {
+                  refetchElement();
+                  setSettingChanged(false);
+                }}
               >
                 <LuRefreshCw size={20} /> Fetch
                 <Tooltip anchorSelect=".getelement" place="top">

--- a/frontend/src/styles/_layout.scss
+++ b/frontend/src/styles/_layout.scss
@@ -237,11 +237,11 @@ table{
   background-color: $primary;
   border: 3px rgba(0,0,0,0) solid;
   border-radius: 5px;
+  color: white;
 }
 
 .getelement.setting-changed{
   animation: glow 1.5s ease-in-out infinite alternate;
-  color: white;
 }
 
 @-webkit-keyframes glow {


### PR DESCRIPTION
there was two tiny bugs: 
- the glow would not stop after fetching new items
- the color turned white only after changing