### PR TITLE
rewrite history and add comment

### DIFF
--- a/api/activetigger/app/routers/schemes.py
+++ b/api/activetigger/app/routers/schemes.py
@@ -37,7 +37,7 @@ async def rename_label(
         project.schemes.rename_label(former_label, new_label, scheme, current_user.username)
         orchestrator.log_action(
             current_user.username,
-            f"RENAME LABEL: in {scheme} label {former_label} to {new_label}",
+            f"RENAME LABEL: scheme:{scheme} before:{former_label} after:{new_label}",
             project.name,
         )
         return None
@@ -63,7 +63,7 @@ async def add_label(
 
             orchestrator.log_action(
                 current_user.username,
-                f"ADD LABEL: in {scheme} label {label}",
+                f"ADD LABEL: scheme:{scheme} label:{label}",
                 project.name,
             )
             return None
@@ -76,7 +76,7 @@ async def add_label(
             project.schemes.delete_label(label, scheme, current_user.username)
             orchestrator.log_action(
                 current_user.username,
-                f"DELETE LABEL: in {scheme} label {label}",
+                f"DELETE LABEL: scheme:{scheme} label:{label}",
                 project.name,
             )
             return None

--- a/api/activetigger/schemes.py
+++ b/api/activetigger/schemes.py
@@ -270,44 +270,25 @@ class Schemes:
         """
         Convert tags from a specific label to another
         """
+        available = self.available()
+        if scheme not in available:
+            raise Exception("Scheme doesn't exist")
         # test if the new label exist, either create it
         if not self.exists_label(scheme, new_label):
             self.add_label(new_label, scheme, username)
 
-        # add a new tag for the annotated id in the trainset
-        df_train = self.get_scheme(scheme, datasets=["train"])
-        elements_train = [
-            {"element_id": element_id, "annotation": new_label, "comment": "label renamed"}
-            for element_id in list(df_train[df_train["labels"] == former_label].index)
-        ]
-        df_test = self.get_scheme(scheme, datasets=["test"])
-        elements_test = [
-            {"element_id": element_id, "annotation": new_label, "comment": "label renamed"}
-            for element_id in list(df_test[df_test["labels"] == former_label].index)
-        ]
-
-        # add the new tags in train/test
-        self.db_manager.projects_service.add_annotations(
-            dataset="train",
-            user_name=username,
+        # convert the tags in the database (add new tag and delete old one)
+        self.db_manager.projects_service.rename_label(
             project_slug=self.project_slug,
             scheme=scheme,
-            elements=elements_train,
-        )
-        self.db_manager.projects_service.add_annotations(
-            dataset="test",
-            user_name=username,
-            project_slug=self.project_slug,
-            scheme=scheme,
-            elements=elements_test,
+            former_label=former_label,
+            new_label=new_label,
         )
 
         # update the scheme (no need to add empty annotation in the database)
-        available = self.available()
-        if scheme not in available:
-            raise Exception("Scheme doesn't exist")
         labels = available[scheme].labels
         labels.remove(former_label)
+        labels.append(new_label)
         self.update_scheme(scheme, labels)
 
     def get_total(self, dataset: str = "train") -> int:

--- a/frontend/src/components/LabelsManagement.tsx
+++ b/frontend/src/components/LabelsManagement.tsx
@@ -90,7 +90,7 @@ export const LabelCard: FC<LabelCardProps> = ({
       </Modal>
       <Modal show={showRename} onHide={() => setShowRename(false)}>
         <Modal.Header closeButton>
-          <Modal.Title>Rename {label}</Modal.Title>
+          <Modal.Title>Rename label {label}</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           <input


### PR DESCRIPTION
To avoid to rename the scheme only for the acting user (adding entry with its username), change the database elements directly.

Add a comment in each element modified to keep track of this change.

Closes #783