### PR TITLE
add use effect to auto refetch after retraining

### DIFF
--- a/frontend/src/components/ModelManagement.tsx
+++ b/frontend/src/components/ModelManagement.tsx
@@ -121,11 +121,16 @@ export const ModelManagement: FC = () => {
   };
 
   // get information on the quickmodel
-  const { currentModel: currentQuickModelInformations } = useGetQuickModel(
+  const { currentModel: currentQuickModelInformations, reFetchQuickModel } = useGetQuickModel(
     projectSlug || null,
     currentQuickModelName,
     currentQuickModelName,
   );
+  useEffect(() => {
+    if (currentQuickModelInformations) {
+      reFetchQuickModel();
+    }
+  }, [isComputing]);
 
   // delete quickmodel
   const { deleteQuickModel } = useDeleteQuickModel(projectSlug || null);
@@ -205,8 +210,6 @@ export const ModelManagement: FC = () => {
     currentProject,
   ]);
 
-  console.log(isComputing);
-
   return (
     <>
       <span className="fw-semibold text-muted small">Quick Models</span>
@@ -260,7 +263,10 @@ export const ModelManagement: FC = () => {
           projectSlug={projectSlug || null}
           processes={
             currentProject?.languagemodels.training?.[authenticatedUser.username]
-              ? { [authenticatedUser.username]: currentProject.languagemodels.training[authenticatedUser.username] }
+              ? {
+                  [authenticatedUser.username]:
+                    currentProject.languagemodels.training[authenticatedUser.username],
+                }
               : undefined
           }
           displayStopButton={isComputing}


### PR DESCRIPTION
if a quickmodel is selected, and iscomputing is changing, then refetch the quickmodel information. 

Might not be optimal because there might be — at least — twice as many refreshes as necessary, but for now we do not have a specific information "model A is training" or "model A is retraining". Could be an enhancement 

Closes #854 