### PR TITLE
Create a similar search interface between explore and annotate

### DIFF
--- a/api/activetigger/datamodels.py
+++ b/api/activetigger/datamodels.py
@@ -748,9 +748,11 @@ class TableBatchInModel(BaseModel):
     scheme: str
     min: int = 0
     max: int = 0
-    mode: str = "all"
     contains: str | None = None
     dataset: str = "train"
+    on_users: list[str] | None = None
+    on_labels: list[str] | None = None
+    recent: bool = False
 
 
 class ProjectsServerModel(BaseModel):

--- a/api/activetigger/schemes.py
+++ b/api/activetigger/schemes.py
@@ -340,16 +340,14 @@ class Schemes:
         """
         Get data table
         scheme : the annotations
+        dataset: the dataset
         min, max: the range
-        mode: sample
-        contains: search
-
-        set: train or test
+        contains: matching regex
+        on_users: list of users
+        on_labels: list of labels
 
         Choice to order by index.
         """
-        if batch.mode not in ["tagged", "untagged", "all", "recent"]:
-            batch.mode = "all"
         if batch.scheme not in self.available():
             raise Exception(f"Scheme {batch.scheme} is not available")
 
@@ -365,7 +363,7 @@ class Schemes:
         df["timestamp"] = df["timestamp"].apply(lambda x: str(x) if pd.notna(x) else "")
 
         # case of recent annotations (no filter possible)
-        if batch.mode == "recent":
+        if batch.recent:
             list_ids = self.projects_service.get_recent_annotations(
                 self.project_slug, user, batch.scheme, batch.max - batch.min, batch.dataset
             )
@@ -373,31 +371,28 @@ class Schemes:
             table = df_r
             total = len(df_r)
         else:
-            # filters for labels
+            # filters for labels & users
             f_labels = pd.Series([True] * len(df), index=df.index)
-            if batch.mode == "tagged":
-                f_labels = df["labels"].notnull()
-            if batch.mode == "untagged":
-                f_labels = df["labels"].isnull()
+            if batch.on_users:
+                f_labels = f_labels & df["user"].isin(batch.on_users)
+            if batch.on_labels:
+                f_labels = f_labels & df["labels"].isin(batch.on_labels)
 
             # filter for patterns
             f_contains = pd.Series([True] * len(df), index=df.index)
             if batch.contains:
                 if batch.contains.startswith("ALL:") and len(batch.contains) > 4:
-                    contains_f = batch.contains.replace("ALL:", "")
+                    contains_f = batch.contains.replace("ALL=", "")
                     f_l = df["labels"].str.contains(clean_regex(contains_f)).fillna(False)
                     f_text = df["text"].str.contains(clean_regex(contains_f)).fillna(False)
                     f_contains = f_l | f_text
                 elif batch.contains == "HAS_COMMENT":
                     f_contains = df["comment"].fillna("").str.len() > 0
-                elif batch.contains.startswith("COMMENT:") and len(batch.contains) > 8:
-                    contains_f = batch.contains.replace("COMMENT:", "")
-                    f_contains = df["comment"].str.contains(
-                        clean_regex(contains_f)
-                    ).fillna(False)
+                elif batch.contains.startswith("COMMENT=") and len(batch.contains) > 8:
+                    contains_f = batch.contains.replace("COMMENT=", "")
+                    f_contains = df["comment"].str.contains(clean_regex(contains_f)).fillna(False)
                 else:
                     f_contains = df["text"].str.contains(clean_regex(batch.contains))
-
             df = df[f_contains & f_labels]
 
             # normalize size

--- a/frontend/src/components/DataTabular.tsx
+++ b/frontend/src/components/DataTabular.tsx
@@ -13,6 +13,7 @@ import { Tooltip } from 'react-tooltip';
 import { useAddTableAnnotations, useTableElements } from '../core/api';
 import { AppContextValue } from '../core/context';
 import { AnnotationModel } from '../types';
+import { TableFilterState, TableTagFilterSelect } from './TableTagFilterSelect';
 
 interface Row {
   id_internal: string;
@@ -27,6 +28,7 @@ interface DataTabularModel {
   projectSlug: string;
   currentScheme: string;
   availableLabels: string[];
+  availableUsers: string[];
   kindScheme: string;
   isValid: boolean;
   isTest: boolean;
@@ -38,6 +40,7 @@ export const DataTabular: FC<DataTabularModel> = ({
   projectSlug,
   currentScheme,
   availableLabels,
+  availableUsers,
   kindScheme,
   isValid,
   isTest,
@@ -66,9 +69,13 @@ export const DataTabular: FC<DataTabularModel> = ({
 
   // selection elements
   const [page, setPage] = useState<number | null>(1);
-  const [search, setSearch] = useState<string | null>(null);
-  const [sample, setSample] = useState<string>('all');
+  const [contains, setContains] = useState<string | null>(null);
   const [pageSize, setPageSize] = useState(20);
+  const [filter, setFilter] = useState<TableFilterState>({
+    recent: false,
+    labels: [],
+    users: [],
+  });
   const [changeTrigger, setChangeTrigger] = useState<boolean>(false);
 
   // get API elements when table shape change
@@ -76,7 +83,17 @@ export const DataTabular: FC<DataTabularModel> = ({
     table,
     getPage,
     total: totalElement,
-  } = useTableElements(projectSlug, currentScheme, page, pageSize, search, sample, currentDataset);
+  } = useTableElements(
+    projectSlug,
+    currentScheme,
+    page,
+    pageSize,
+    currentDataset,
+    contains,
+    filter.recent,
+    filter.labels,
+    filter.users,
+  );
 
   const [rows, setRows] = useState<Row[]>([]);
 
@@ -153,7 +170,7 @@ export const DataTabular: FC<DataTabularModel> = ({
         >
           <Highlighter
             highlightClassName="Search"
-            searchWords={search && isValidRegex(search) ? [search.replace('ALL:', '')] : []}
+            searchWords={contains && isValidRegex(contains) ? [contains.replace('ALL:', '')] : []}
             autoEscape={false}
             textToHighlight={props.row.text}
             highlightStyle={{
@@ -247,32 +264,29 @@ export const DataTabular: FC<DataTabularModel> = ({
             {isTest && <option value="test">test</option>}
           </select>
         </div>
-        <div>
-          <label>Tagged</label>
-          <select
-            onChange={(e) => {
+        <div style={{ minWidth: 220 }}>
+          <label>Filter by Tag/Users</label>
+          <TableTagFilterSelect
+            availableLabels={availableLabels}
+            availableUsers={availableUsers}
+            onChange={(f) => {
               setPage(1);
-              setSample(e.target.value);
+              setFilter(f);
             }}
-            value={sample}
-          >
-            {['tagged', 'untagged', 'all', 'recent'].map((e) => (
-              <option key={e}>{e}</option>
-            ))}
-          </select>
+          />
         </div>
         <div>
           <label htmlFor="filter-input">
-            Filter
+            Filter by content
             <HiOutlineQuestionMarkCircle className="search" />
-            {!isValidRegex(search || '') && <span className="badge danger">Regex not valid</span>}
+            {!isValidRegex(contains || '') && <span className="badge danger">Regex not valid</span>}
           </label>
           <input
             placeholder="Regex filter on text"
             id="filter-input"
             onChange={(e) => {
               setPage(1);
-              setSearch(e.target.value);
+              setContains(e.target.value);
             }}
           />
         </div>
@@ -362,7 +376,7 @@ export const DataTabular: FC<DataTabularModel> = ({
         </Modal.Footer>
       </Modal>
       <Tooltip anchorSelect=".search">
-        Special search: ALL: text/label, COMMENT: in comments, HAS_COMMENT
+        Special search: ALL= in all text/label, COMMENT= in comments, HAS_COMMENT
       </Tooltip>
     </>
   );

--- a/frontend/src/components/TableTagFilterSelect.tsx
+++ b/frontend/src/components/TableTagFilterSelect.tsx
@@ -1,0 +1,142 @@
+import { FC, useCallback, useMemo } from 'react';
+import { CiClock1 } from 'react-icons/ci';
+import Select, { MultiValueGenericProps, OptionProps, components } from 'react-select';
+
+import { sortBy, uniq } from 'lodash';
+import { truncateInMiddle } from '../core/utils';
+import { AnnotationIcon, UserIcon } from './Icons';
+
+export interface TableFilterState {
+  recent: boolean;
+  labels: string[];
+  users: string[];
+}
+
+interface TableFilterOption {
+  sample: 'recent' | 'label' | 'user';
+  label?: string;
+  user?: string;
+  value: string;
+}
+
+interface TableTagFilterSelectProps {
+  availableLabels: string[];
+  availableUsers: string[];
+  onChange: (filter: TableFilterState) => void;
+}
+
+function optionValue(option: Omit<TableFilterOption, 'value'>) {
+  return [option.sample, option.label || '', option.user || ''].join('|');
+}
+
+/**
+ * Custom react-select rendering
+ */
+const OptionIcon: FC<{ option: TableFilterOption }> = ({ option }) => (
+  <>
+    {option.sample === 'recent' && <CiClock1 className="me-1" />}
+    {option.sample === 'label' && <AnnotationIcon className="me-1" />}
+    {option.sample === 'user' && <UserIcon className="me-1" />}
+  </>
+);
+
+const MultiValueLabel = ({ children, ...props }: MultiValueGenericProps<TableFilterOption>) => {
+  return (
+    <components.MultiValueLabel {...props}>
+      <OptionIcon option={props.data} />
+      {children}
+    </components.MultiValueLabel>
+  );
+};
+
+const Option = ({ children, ...props }: OptionProps<TableFilterOption>) => {
+  return (
+    <components.Option {...props}>
+      <OptionIcon option={props.data} />
+      {children}
+    </components.Option>
+  );
+};
+
+/**
+ * Multi-select filter for the tabular data view.
+ * Allows filtering by labels, users, or showing recent annotations.
+ */
+export const TableTagFilterSelect: FC<TableTagFilterSelectProps> = ({
+  availableLabels,
+  availableUsers,
+  onChange,
+}) => {
+  const options: TableFilterOption[] = useMemo(() => {
+    const recentOption: TableFilterOption = {
+      sample: 'recent',
+      value: optionValue({ sample: 'recent' }),
+    };
+    const labelOptions: TableFilterOption[] = availableLabels.map((l) => ({
+      sample: 'label' as const,
+      label: l,
+      value: optionValue({ sample: 'label', label: l }),
+    }));
+    const userOptions: TableFilterOption[] = availableUsers.map((u) => ({
+      sample: 'user' as const,
+      user: u,
+      value: optionValue({ sample: 'user', user: u }),
+    }));
+    return [recentOption, ...labelOptions, ...userOptions];
+  }, [availableLabels, availableUsers]);
+
+  // recent is incompatible with label/user filters
+  const isOptionDisabled = useCallback(
+    (option: TableFilterOption, selectValue: readonly TableFilterOption[]) => {
+      if (selectValue.length === 0) return false;
+      const hasRecent = selectValue.some((o) => o.sample === 'recent');
+      if (hasRecent) return option.sample !== 'recent';
+      return option.sample === 'recent';
+    },
+    [],
+  );
+
+  return (
+    <Select<TableFilterOption, true>
+      className="react-select"
+      isMulti
+      isClearable
+      placeholder="All elements"
+      options={options}
+      isOptionDisabled={(option, selectValue) => isOptionDisabled(option, selectValue)}
+      getOptionLabel={(o) =>
+        truncateInMiddle(
+          o.sample === 'label' && o.label !== undefined
+            ? o.label
+            : o.sample === 'user' && o.user !== undefined
+              ? `by ${o.user}`
+              : o.sample === 'recent'
+                ? 'recent'
+                : '',
+          20,
+        )
+      }
+      components={{ MultiValueLabel, Option }}
+      onChange={(selected) => {
+        if (!selected || selected.length === 0) {
+          onChange({ recent: false, labels: [], users: [] });
+          return;
+        }
+        const arr = [...selected];
+        if (arr.some((o) => o.sample === 'recent')) {
+          onChange({ recent: true, labels: [], users: [] });
+        } else {
+          onChange({
+            recent: false,
+            labels: sortBy(
+              uniq(arr.filter((o) => o.label !== undefined).map((o) => o.label as string)),
+            ),
+            users: sortBy(
+              uniq(arr.filter((o) => o.user !== undefined).map((o) => o.user as string)),
+            ),
+          });
+        }
+      }}
+    />
+  );
+};

--- a/frontend/src/core/api.ts
+++ b/frontend/src/core/api.ts
@@ -1631,9 +1631,11 @@ export function useTableElements(
   scheme?: string,
   initialPage?: number | null,
   initialPageSize?: number | null,
-  search?: string | null,
-  sample?: string,
   dataset?: string,
+  contains?: string | null,
+  recent?: boolean,
+  on_labels?: string[],
+  on_users?: string[],
 ) {
   const [pageInfo, setPageInfo] = useState<PageInfo>({
     pageIndex: initialPage || 1,
@@ -1654,9 +1656,11 @@ export function useTableElements(
           scheme: scheme,
           min: (pageInfo.pageIndex - 1) * pageInfo.pageSize,
           max: Math.min(pageInfo.pageIndex * pageInfo.pageSize, total),
-          contains: search,
-          mode: sample ? sample : 'all',
+          contains: contains,
           dataset: dataset ? dataset : 'train',
+          recent: recent ? recent : false,
+          on_labels: on_labels ? on_labels : null,
+          on_users: on_users ? on_users : null,
         },
       });
       if (!res.error) {
@@ -1665,7 +1669,7 @@ export function useTableElements(
       }
     }
     return null;
-  }, [scheme, pageInfo, search, sample]);
+  }, [scheme, pageInfo, project_slug, contains, dataset, recent, on_labels, on_users]);
 
   return { table: getAsyncMemoData(getTableElements), total, getPage: setPageInfo };
 }

--- a/frontend/src/generated/openapi.d.ts
+++ b/frontend/src/generated/openapi.d.ts
@@ -3344,11 +3344,6 @@ export interface components {
              * @default 0
              */
             max: number;
-            /**
-             * Mode
-             * @default all
-             */
-            mode: string;
             /** Contains */
             contains?: string | null;
             /**
@@ -3356,6 +3351,15 @@ export interface components {
              * @default train
              */
             dataset: string;
+            /** On Users */
+            on_users?: string[] | null;
+            /** On Labels */
+            on_labels?: string[] | null;
+            /**
+             * Recent
+             * @default false
+             */
+            recent: boolean;
         };
         /**
          * TableOutModel

--- a/frontend/src/pages/ProjectExplorePage.tsx
+++ b/frontend/src/pages/ProjectExplorePage.tsx
@@ -41,6 +41,7 @@ export const ProjectExplorePage: FC = () => {
                   projectSlug={projectName || ''}
                   currentScheme={currentScheme || ''}
                   availableLabels={availableLabels}
+                  availableUsers={project?.users?.users ?? []}
                   kindScheme={kindScheme}
                   isValid={project?.params.valid || false}
                   isTest={project?.params.test || false}

--- a/frontend/src/styles/_data_table.scss
+++ b/frontend/src/styles/_data_table.scss
@@ -126,11 +126,11 @@
 }
 
 #tabular-view-control-panel{
-  div{
+  > div{
     flex: 1 1 auto;
     min-width: 200px;
     margin: 2px 5px;
-    
+
     label{
       font-style: italic;
       color: $dark-grey-color;


### PR DESCRIPTION
Solve issue #846 

Minimal choice:
- transform the API to mimic get next
- add a component to have a crafted Select 