### PR TITLE
Sanitize input dataset

### DIFF
--- a/api/activetigger/data.py
+++ b/api/activetigger/data.py
@@ -55,19 +55,26 @@ class Data:
         self.test = None
         self.load_dataset("all")
 
-    @staticmethod
-    def read_dataset(file_path: Path) -> DataFrame:
+    def _sanitize_dataset(df: DataFrame) -> DataFrame:
+        """
+        Strips any leading/trailing white spaces in columns
+        """
+        for col in df.select_dtypes(include = 'str'):
+            df[col] = df[col].str.strip()
+        return df
+    
+    def read_dataset(self, file_path: Path) -> DataFrame:
         """
         Read a data file and return a DataFrame
         """
         if not file_path.exists():
             raise FileNotFoundError(f"Data file not found: {file_path}")
         if file_path.suffix.lower() == ".csv":
-            return pd.read_csv(file_path)
+            return self._sanitize_dataset(pd.read_csv(file_path))
         elif file_path.suffix.lower() == ".parquet":
-            return pd.read_parquet(file_path)
+            return self._sanitize_dataset(pd.read_parquet(file_path))
         elif file_path.suffix.lower() == ".xlsx":
-            return pd.read_excel(file_path)
+            return self._sanitize_dataset(pd.read_excel(file_path))
         else:
             raise ValueError(f"Unsupported file format: {file_path}")
 


### PR DESCRIPTION
This PR sanitizes input dataset to remove any leading/trailing white spaces in the input dataset. Currently it looks for string columns and apply `strip()` function. In the future we can add any further sanitization required in this internal method.