### PR TITLE
feat: add WaX feature

### DIFF
--- a/api/activetigger/XAi/wax.py
+++ b/api/activetigger/XAi/wax.py
@@ -1,0 +1,119 @@
+import torch
+import numpy as np
+import matplotlib.pyplot as plt
+from torch import nn
+from scipy.spatial.distance import cdist
+
+#--------------------------------------WAX-------------------------------------------------------------------#
+#'Weistrassian Distance made explainable's paper implementation 2026
+#
+#
+#
+#
+#
+#------------------------------------------------------------------------------------------------------------#
+  
+def compute_sinkhorn(Xs: torch.Tensor, Yt: torch.Tensor, reg: float=0.01, num_iter: int=100, p: int=2) -> torch.Tensor:
+  Xs_np = Xs.detach().numpy()
+  Yt_np = Yt.detach().numpy()
+  cost_matrix = cdist(Xs_np, Yt_np, metric='minkowski', p=p)
+  K = np.exp(-cost_matrix / cost_matrix.max() / reg)
+  n, m = K.shape
+  mu = np.ones(n) / n
+  nu = np.ones(m) / m
+  u = np.ones(n)
+  v = np.ones(m)
+  for _ in range(num_iter):
+      v = nu / (K.T @ u + 1e-10)
+      u = mu / (K @ v + 1e-10)
+  return torch.tensor(np.atleast_2d(u).T*(K*v.T),dtype=torch.float32)
+
+class WaX():
+  def __init__(self,X:torch.Tensor,Y:torch.Tensor,p:int,q:int,alpha:int,beta:int,n:int=100,reg :float=0.01):
+    self.X = X.clone().requires_grad_(True)
+    self.Y = Y.clone().requires_grad_(True)
+    self.p = p
+    self.q = q
+    self.alpha = alpha
+    self.beta = beta
+    self.W=None
+    #optimal transport
+    self.gamma_star=compute_sinkhorn(Xs=X,Yt=Y,reg=reg,num_iter=n,p=self.q).detach()
+    print("*gam",self.gamma_star)
+    self.z_q=None
+    self.z_beta=None
+    self.z_kl=None
+    #neutralization
+    #constructing the neural network
+    #Wasserstein distance
+  def forward(self):
+    self.z_q = torch.cdist(self.X,self.Y,p=self.q)
+    print("zq",self.z_q.isnan().any())
+    self.z_beta=torch.cdist(self.X,self.Y,p=self.beta)
+    print("zz",self.z_beta.isnan().any())
+    if self.beta == self.q:
+      self.z_kl = self.z_q
+    else:
+      self.z_kl=self.z_beta * (self.z_q/self.z_beta).detach()
+    print("zzz",self.z_kl.isnan().any())
+    print(f"z_kl grad_fn:{self.z_kl.grad_fn}")
+    W_p=torch.pow((self.gamma_star*(self.z_kl**self.p)).sum(),(1/self.p))
+    print("w_p",W_p)
+    W_alpha=torch.pow((self.gamma_star*(self.z_kl**self.alpha)).sum(),(1/self.alpha))
+    print("w_alpha",W_alpha)
+    self.W=W_alpha*(W_p/W_alpha).detach()
+    print("disatnc",self.W)
+    return self.W
+  def explain(self):
+    self.X = self.X.detach().clone().requires_grad_(True)
+    self.Y = self.Y.detach().clone().requires_grad_(True)
+    print(self.X)
+    self.forward()
+    self.W.backward()
+    Ri = (self.X*self.X.grad).sum(0) + (self.Y*self.Y.grad).sum(0)
+    print(f"WaX done | W_p = {self.W.item():.6f} | sum(R_i) = {Ri.sum().item():.6f}")
+    return Ri
+  
+class U_WaX:
+  def __init__(self, Xs: torch.Tensor, Yt: torch.Tensor, r: int = 4, C: int = 3,lr: float = 0.01, n_iter: int = 200):
+    self.d = Xs.shape[1]
+    self.Xs = Xs.clone()
+    self.Yt = Yt.clone()
+    self.r = r
+    self.C = C
+    self.gamma_star = compute_sinkhorn(Xs, Yt, reg=0.01, num_iter=50).detach()
+    U = torch.randn(self.d, self.d, device=Xs.device)
+    self.U, _ = torch.linalg.qr(U)
+    self.U.requires_grad_(True)
+    optimizer = torch.optim.Adam([self.U], lr=lr)
+    # ====================== OPTIMIZATION LOOP ======================
+    for _ in range(n_iter):
+        optimizer.zero_grad()
+        diff = self.Xs.unsqueeze(1) - self.Yt.unsqueeze(0)        
+        zc = torch.einsum('nmd,dc->nmc', diff, self.U)            
+        Qc = torch.pow((self.gamma_star.unsqueeze(-1) * (zc.abs() ** self.r)).sum((0,1)), 1.0 / self.r)
+        loss = -Qc[:self.C].sum()                                  
+        loss.backward()
+        optimizer.step()
+        with torch.no_grad():
+            self.U.data = torch.linalg.qr(self.U.data)[0]
+    self.U = self.U.detach()
+  def explain(self):
+    """Returns Rc and Rci (concept relevances + per-feature relevances)"""
+    diff = self.Xs.unsqueeze(1) - self.Yt.unsqueeze(0)
+    zc = torch.einsum('nmd,dc->nmc', diff, self.U[:, :self.C])
+    Sc = (self.gamma_star.unsqueeze(-1) * zc**2).sum((0,1)).sqrt()
+    W2 = Sc.norm(p=2)
+    Rc = (Sc**2 / (Sc**2).sum()) * W2
+    Rckl_num = self.gamma_star.unsqueeze(-1) * (zc**2)
+    Rckl = Rckl_num / Rckl_num.sum((0,1), keepdim=True) * Rc.unsqueeze(0).unsqueeze(0)
+    Rci = torch.zeros((self.C, self.d), device=self.Xs.device)
+    for c in range(self.C):
+        Uc = self.U[:, c:c+1]                                 
+        hat_diff=(diff @ Uc) @ Uc.T                       
+        num=diff * hat_diff
+        den=num.sum(dim=-1, keepdim=True) + 1e-10
+        weight=num/den
+        Rci[c]=(weight * Rckl[..., c:c+1]).sum((0, 1))
+    return Rc, Rci
+  

--- a/api/activetigger/tasks/compute_wax.py
+++ b/api/activetigger/tasks/compute_wax.py
@@ -1,0 +1,47 @@
+from ..XAi.wax import WaX, U_WaX
+from activetigger.tasks.base_task import BaseTask
+from activetigger.tasks.compute_sbert import ComputeSbert
+import torch
+import pandas as pd
+from pathlib import Path
+
+class ComputeWaXUWaX(BaseTask):
+    kind = "compute_wax_uwax"
+    def __init__(self,source_texts:list[str],target_texts:list[str],path_process:Path,model:str="all-MiniLM-L6-v2",p:int=2,q:int=2,alpha:int=2,beta:int=2,n:int=100,reg:float=0.01,r:int=4,C:int=3,lr:float=0.01,n_iter:int=200):
+        super().__init__()
+        self.source_texts = source_texts
+        self.target_texts = target_texts
+        self.path_process = path_process
+        self.model = model
+        self.p = p
+        self.q = q
+        self.alpha = alpha
+        self.beta = beta
+        self.n = n
+        self.reg = reg
+        self.r = r
+        self.C = C
+        self.lr = lr
+        self.n_iter = n_iter
+    def __call__(self):
+        # Embed source and target texts using ComputeSbert
+        #print(self.source_texts.shape, self.target_texts.shape)
+        source_series = pd.Series(self.source_texts)
+        target_series = pd.Series(self.target_texts)
+        csbert_source = ComputeSbert(texts=source_series,path_process=self.path_process,model=self.model)
+        csbert_target = ComputeSbert(texts=target_series,path_process=self.path_process,model=self.model)
+        X = torch.tensor(csbert_source().values, dtype=torch.float32)
+        Y = torch.tensor(csbert_target().values, dtype=torch.float32)
+        wax = WaX(X, Y, self.p, self.q, self.alpha, self.beta, self.n, self.reg)
+        wax.forward()
+        gamma = wax.gamma_star          # shape (N, M)
+        z_kl = wax.z_kl                 # shape (N, M)
+        numerator = gamma * (z_kl ** self.alpha)
+        denominator = numerator.sum()
+        R_kl = numerator / denominator * wax.W   # Eq. (3a) from paper
+        instance_relevance = R_kl.sum(axis=0).tolist()
+        Ri = wax.explain()
+        #leave for confirmation of pull request
+        #uwax = U_WaX(X, Y, self.r, self.C, self.lr, self.n_iter)
+        #Rc, Rci = uwax.explain()
+        return {"wax_distance": wax.W.item(),"feature_relevance": Ri.tolist(),"instance_relevance":instance_relevance}

--- a/frontend/src/components/Annotation/MulticlassInput.tsx
+++ b/frontend/src/components/Annotation/MulticlassInput.tsx
@@ -8,6 +8,7 @@ import { reorderLabels } from '../../core/utils';
 import { ElementOutModel } from '../../types';
 import { ActiveAnnotationIcon, EmptyAnnotationIcon, NoAnnotationIcon } from '../Icons';
 import { MiddleEllipsis } from './MiddleEllipsis';
+import { WaxAnalysisModal } from '../../components/vizualisation/DisplayWaX';
 
 interface MulticlassInputProps {
   elementId: string;
@@ -17,6 +18,8 @@ interface MulticlassInputProps {
   phase?: string;
   element?: ElementOutModel;
   secondaryLabels?: boolean;
+  currentScheme?: string;   
+  dataset?: string;  
 }
 
 interface LabelType {
@@ -32,8 +35,9 @@ export const MulticlassInput: FC<MulticlassInputProps> = ({
   element,
   small = false,
   secondaryLabels = true,
+  currentScheme ='',
+  dataset = 'train',
 }) => {
-  // get the context and set the labels
   const {
     appContext: { displayConfig, activeModel },
   } = useAppContext();
@@ -42,8 +46,9 @@ export const MulticlassInput: FC<MulticlassInputProps> = ({
 
   const { addElementInAnnotationSessionHistory } = useAnnotationSessionHistory();
 
+  const [showWax, setShowWax] = useState(false);
+
   const skipAnnotation = useCallback(() => {
-    //update history
     if (element)
       addElementInAnnotationSessionHistory(
         element.element_id,
@@ -52,17 +57,13 @@ export const MulticlassInput: FC<MulticlassInputProps> = ({
         undefined,
         true,
       );
-
-    // move to next element
     navigate(`/projects/${projectName}/tag/`);
   }, [navigate, projectName, addElementInAnnotationSessionHistory, element]);
 
-  //grab comment from element history once API has been modified to add this
   const [comment, setComment] = useState<string>(
     element?.history ? element.history[0]?.comment || '' : '',
   );
 
-  //reset comment as for now it's not available in annotation history
   useEffect(() => setComment(element?.history ? element.history[0]?.comment || '' : ''), [element]);
 
   const availableLabels = useMemo<LabelType[]>(
@@ -76,7 +77,6 @@ export const MulticlassInput: FC<MulticlassInputProps> = ({
 
   const handleKeyboardEvents = useCallback(
     (ev: KeyboardEvent) => {
-      // prevent shortkey to perturb the inputs
       const activeElement = document.activeElement;
       const isFormField =
         activeElement?.tagName === 'INPUT' ||
@@ -104,11 +104,9 @@ export const MulticlassInput: FC<MulticlassInputProps> = ({
   );
 
   useEffect(() => {
-    // manage keyboard shortcut if less than 10 label
     if (availableLabels.length > 0 && availableLabels.length < 10) {
       document.addEventListener('keydown', handleKeyboardEvents);
     }
-
     return () => {
       if (availableLabels.length > 0 && availableLabels.length < 10) {
         document.removeEventListener('keydown', handleKeyboardEvents);
@@ -117,52 +115,67 @@ export const MulticlassInput: FC<MulticlassInputProps> = ({
   }, [availableLabels, handleKeyboardEvents]);
 
   const predict_proba = element?.predict.proba ? element.predict.proba.toFixed(2) : 'NA';
-  // const predict_entropy = element?.predict.entropy ? element.predict.entropy.toFixed(2) : 'NA';
 
   const lastAnnotation = useMemo(() => {
     return element?.history && element.history.length > 0 ? element?.history[0] : null;
   }, [element?.history]);
 
   return (
-    <div className=" tag-action-container">
+    <div className="tag-action-container">
       {/* TAGS ACTIONS */}
-
-      {
-        // display buttons for label from the user
-        availableLabels.map((e, i) => (
-          <button
-            type="button"
-            key={e.label}
-            value={e.label}
-            className="tag-action-button btn-annotate-action"
-            onClick={(v) => {
-              if (element) postAnnotation(v.currentTarget.value, elementId, comment);
-            }}
-          >
-            {displayConfig.displayAnnotation ? (
-              lastAnnotation && lastAnnotation.label === e.label ? (
-                <ActiveAnnotationIcon />
-              ) : (
-                <EmptyAnnotationIcon />
-              )
-            ) : null}
-            <MiddleEllipsis label={e.label} />
-            {availableLabels.length < 10 && <span className="badge hotkey">{i + 1}</span>}
-          </button>
-        ))
-      }
+      {availableLabels.map((e, i) => (
+        <button
+          type="button"
+          key={e.label}
+          value={e.label}
+          className="tag-action-button btn-annotate-action"
+          onClick={(v) => {
+            if (element) postAnnotation(v.currentTarget.value, elementId, comment);
+          }}
+        >
+          {displayConfig.displayAnnotation ? (
+            lastAnnotation && lastAnnotation.label === e.label ? (
+              <ActiveAnnotationIcon />
+            ) : (
+              <EmptyAnnotationIcon />
+            )
+          ) : null}
+          <MiddleEllipsis label={e.label} />
+          {availableLabels.length < 10 && <span className="badge hotkey">{i + 1}</span>}
+        </button>
+      ))}
+      {secondaryLabels && (
+        <button
+          type="button"
+          className="btn-annotate-general-action tag-action-button"
+          onClick={() => setShowWax(true)}
+          disabled={!currentScheme}
+          title={!currentScheme ? 'No scheme selected' : 'WAX suggest'}
+        >
+          WAX suggest
+        </button>
+      )}
+      {projectName && (
+        <WaxAnalysisModal
+          show={showWax}
+          onHide={() => setShowWax(false)}
+          projectSlug={projectName}
+          scheme={currentScheme}
+          dataset={dataset}
+        />
+      )}
 
       {/* PREDICTION */}
       {phase == 'train' && displayConfig.displayPrediction && element?.predict.label && (
         <div className="prediction-container">
-          {/* {displayConfig.displayPredictionStat && (
+        {/* {displayConfig.displayPredictionStat && (
             <small className="d-flex align-items-center gap-1 prediction-stats">
               <MdOnlinePrediction size="20" title="Prediction by model" id="prediction-icon" />{' '}
               <Tooltip anchorSelect="#prediction-icon" place="top">
-                Prediction by model
-              </Tooltip>
+                 Prediction by model
+               </Tooltip>
               <Tooltip anchorSelect="#predict-probability" place="top">
-                prediction's probability: {predict_proba}
+                 prediction's probability: {predict_proba}       
               </Tooltip>
             </small>
           )} */}

--- a/frontend/src/components/vizualisation/DisplayWaX.tsx
+++ b/frontend/src/components/vizualisation/DisplayWaX.tsx
@@ -1,0 +1,312 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { Modal, Button, Spinner, ProgressBar, Alert, Form, Row, Col } from 'react-bootstrap';
+import { VictoryChart, VictoryBar, VictoryTooltip, VictoryTheme, VictoryAxis } from 'victory';
+import { useWaxSuggest } from '../../core/api';
+import { WaxParams } from '../../types';
+
+interface Props {
+  show: boolean;
+  onHide: () => void;
+  projectSlug: string;
+  scheme: string;
+  dataset?: string;
+}
+
+interface WaxResult {
+  wax_distance: number;
+  feature_relevance: number[];
+  elements_id: string[];
+  elements_text: string[];
+  scores: number[];
+  n_labeled: number;
+  n_unlabeled: number;
+}
+
+const DEFAULT_PARAMS: WaxParams = {
+  model: 'all-MiniLM-L6-v2',
+  p: 2, q: 2, alpha: 2, beta: 2,
+  n: 100, reg: 0.01, r: 4, C: 3,
+  lr: 0.01, n_iter: 200, n_suggest: 10,
+};
+
+const POLL_INTERVAL_MS = 2000;
+
+function getTopK(n: number): number {
+  if (n < 50) return n;
+  if (n < 200) return 20;
+  if (n < 1000) return 30;
+  return 50;
+}
+
+type ModalView = 'form' | 'running' | 'done' | 'error';
+
+const PARAM_FIELDS: { key: keyof WaxParams; label: string; desc: string }[] = [
+  { key: 'p',label: 'P',desc: 'Source distribution power' },
+  { key: 'q',label: 'Q',desc: 'Target distribution power' },
+  { key: 'alpha',label: 'Alpha',desc: 'Relevance exponent' },
+  { key: 'beta',label: 'Beta',desc: 'Regularisation exponent' },
+  { key: 'n',label: 'N',desc: 'OT iterations' },
+  { key: 'reg',label: 'Reg',desc: 'Regularisation strength' },
+  // {/* key: 'r',label: 'R',desc: 'U-WaX rank' */},
+  // { /*key: 'C',label: 'C',desc: 'U-WaX clusters' */},
+  // { /*key: 'lr',label: 'LR',desc: 'Learning rate' */},
+  // { /*key: 'n_iter',label: 'N iter', desc: 'U-WaX iterations' },
+  // { /*key: 'n_suggest', label: 'Top-N',  desc: 'Elements to suggest' },
+];
+
+export const WaxAnalysisModal: React.FC<Props> = ({
+  show,
+  onHide,
+  projectSlug,
+  scheme,
+  dataset = 'train',
+}) => {
+  const { start, poll } = useWaxSuggest();
+  const [view, setView]     = useState<ModalView>('form');
+  const [params, setParams] = useState<WaxParams>(DEFAULT_PARAMS);
+  const [result, setResult] = useState<WaxResult | null>(null);
+  const [error, setError]   = useState<string | null>(null);
+  const [elapsed, setElapsed] = useState(0);
+
+  const pollRef    = useRef<ReturnType<typeof setInterval> | null>(null);
+  const timerRef   = useRef<ReturnType<typeof setInterval> | null>(null);
+  const taskIdRef  = useRef<string | null>(null);
+
+  // reset to form each time modal opens
+  useEffect(() => {
+    if (show) {
+      setView('form');
+      setResult(null);
+      setError(null);
+      setElapsed(0);
+    }
+  }, [show]);
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current)  clearInterval(pollRef.current);
+    if (timerRef.current) clearInterval(timerRef.current);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    stopPolling();
+    onHide();
+  }, [stopPolling, onHide]);
+
+  const handleParamChange = useCallback((key: keyof WaxParams, value: string) => {
+    setParams((prev) => ({
+      ...prev,
+      [key]: typeof DEFAULT_PARAMS[key] === 'number' ? Number(value) : value,
+    }));
+  }, []);
+
+  const handleSubmit = useCallback(async () => {
+    if (!scheme) return;
+    setView('running');
+    setElapsed(0);
+
+    timerRef.current = setInterval(() => setElapsed((e) => e + 1), 1000);
+
+    const data = await start(projectSlug, scheme, dataset, params);
+    if (!data) {
+      stopPolling();
+      setError('Failed to start WAX task');
+      setView('error');
+      return;
+    }
+
+    taskIdRef.current = data.task_id;
+    pollRef.current = setInterval(async () => {
+      const currenttaskId=taskIdRef.current;
+      if(!currenttaskId) return;
+      const res = await poll(currenttaskId);
+      if (!res) return;
+      if (res.status === 'done') {
+        stopPolling();
+        setResult(res.result);
+        setView('done');
+      } else if (res.status === 'error') {
+        stopPolling();
+        setError(res.error ?? 'Unknown error');
+        setView('error');
+      }
+    }, POLL_INTERVAL_MS);
+  }, [scheme, projectSlug, dataset, params, start, poll, stopPolling]);
+  const topK = result ? getTopK(result.n_unlabeled) : 0;
+  const maxScore = result ? Math.max(...result.scores) : 1;
+
+  // const featureChartData = result?.feature_relevance.map((v, i) => ({
+  //   x: `F${i + 1}`,
+  //   y: v,
+  // })) ?? [];
+
+  return (
+    <Modal show={show} onHide={handleClose} size="lg" scrollable>
+      <Modal.Header closeButton>
+        <Modal.Title className="d-flex align-items-center gap-2">
+          WAX Analysis
+          {view !== 'form' && (
+            <Button
+              variant="link"
+              size="sm"
+              className="p-0 ms-1"
+              onClick={() => { stopPolling(); setView('form'); }}
+            >
+              ← back to params
+            </Button>
+          )}
+        </Modal.Title>
+      </Modal.Header>
+
+      <Modal.Body>
+        {view === 'form' && (
+          <Form>
+            <Form.Group className="mb-3">
+              <Form.Label><strong>Embedding model</strong></Form.Label>
+              <Form.Control
+                type="text"
+                value={params.model}
+                onChange={(e) => handleParamChange('model', e.target.value)}
+              />
+            </Form.Group>
+
+            <Row>
+              {PARAM_FIELDS.map(({ key, label, desc }) => (
+                <Col xs={6} md={4} key={key} className="mb-3">
+                  <Form.Label>
+                    <strong>{label}</strong>{' '}
+                    <small className="text-muted">{desc}</small>
+                  </Form.Label>
+                  <Form.Control
+                    type="number"
+                    value={params[key]}
+                    step={key === 'reg' || key === 'lr' ? 0.001 : 1}
+                    min={0}
+                    onChange={(e) => handleParamChange(key, e.target.value)}
+                  />
+                </Col>
+              ))}
+            </Row>
+          </Form>
+        )}
+        {view === 'running' && (
+          <div className="text-center py-5">
+            <Spinner animation="border" className="mb-3" />
+             console.log(result);
+            <p className="text-muted mb-3">Running WAX… {elapsed}s elapsed</p>
+            <ProgressBar animated now={100} variant="info" />
+          </div>
+        )}
+        {view === 'error' && (
+          <Alert variant="danger">
+            <strong>WAX failed:</strong> {error}
+          </Alert>
+        )}
+        {view === 'done' && result && (
+          <div>
+
+            {/* summary stats */}
+            <div className="d-flex gap-4 mb-4">
+              <div>
+                <small className="text-muted d-block">Wasserstein Distance</small>
+                <h4 className="mb-0">{result.wax_distance.toFixed(4)}</h4>
+              </div>
+              <div>
+                <small className="text-muted d-block">Labeled</small>
+                <h4 className="mb-0">{result.n_labeled}</h4>
+              </div>
+              <div>
+                <small className="text-muted d-block">Unlabeled</small>
+                <h4 className="mb-0">{result.n_unlabeled}</h4>
+              </div>
+            </div>
+            <h5>Top {topK} suggested elements</h5>
+            <div style={{ overflowX: 'auto' }} className="mb-4">
+              <table className="table table-sm table-hover table-bordered align-middle">
+                <thead className="table-light">
+                  <tr>
+                    <th style={{ width: '5%' }}>#</th>
+                    <th style={{ width: '18%' }}>ID</th>
+                    <th style={{ width: '52%' }}>Text</th>
+                    <th style={{ width: '25%' }}>Score</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {result.elements_id.slice(0, topK).map((id, i) => (
+                    <tr key={id}>
+                      <td className="text-muted text-center">{i + 1}</td>
+                      <td>
+                        <code style={{ fontSize: '0.72rem', wordBreak: 'break-all' }}>
+                          {id}
+                        </code>
+                      </td>
+                      <td>
+                        <div
+                          style={{
+                            maxHeight: '60px',
+                            overflowY: 'auto',
+                            fontSize: '0.85rem',
+                            whiteSpace: 'pre-wrap',
+                            wordBreak: 'break-word',
+                          }}
+                          title={result.elements_text[i]}
+                        >
+                          {result.elements_text[i]}
+                        </div>
+                      </td>
+                      <td>
+                        <div className="d-flex align-items-center gap-2">
+                          <div
+                            style={{
+                              width: `${Math.round((result.scores[i] / maxScore) * 60)}px`,
+                              minWidth: '4px',
+                              height: '8px',
+                              backgroundColor: '#4e79a7',
+                              borderRadius: '4px',
+                              flexShrink: 0,
+                            }}
+                          />
+                          <span style={{ fontSize: '0.8rem', whiteSpace: 'nowrap' }}>
+                            {result.scores[i].toFixed(4)}
+                          </span>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <h5>Feature relevance</h5>
+          </div>
+        )}
+      </Modal.Body>
+
+      <Modal.Footer>
+        {view === 'form' && (
+          <>
+            <Button variant="secondary" onClick={handleClose}>
+              Cancel
+            </Button>
+            <Button variant="primary" onClick={handleSubmit} disabled={!scheme}>
+              Run WAX
+            </Button>
+          </>
+        )}
+        {view === 'running' && (
+          <Button variant="danger" onClick={() => { stopPolling(); setView('form'); }}>
+            Cancel
+          </Button>
+        )}
+        {(view === 'done' || view === 'error') && (
+          <>
+            <Button variant="secondary" onClick={handleClose}>
+              Close
+            </Button>
+            <Button variant="outline-primary" onClick={() => { stopPolling(); setView('form'); }}>
+              Run again
+            </Button>
+          </>
+        )}
+      </Modal.Footer>
+    </Modal>
+  );
+};


### PR DESCRIPTION
feat: add WaX = a natural fit for active learning dataset validity

Context: i remember @jboelaert raised the problem of test set validity and representativeness when he faced this issue `Deterministic trainset broken when valid/test set present` and while researching strategies to tackle this, WaX (Naumann et al. 2025) emerged as  a natural fit , https://arxiv.org/pdf/2505.06123 not just for test set validation but for the active learning loop itself

Further reading on active learning confirmed that the shift between labeled (source)  and unlabeled (target) distributions is a well studied bottleneck in active learning , WaX directly addresses this by making that shift explainable and actionable.

Based on the work of Neumann & al :
- used `computesbert` to get embeddings 
- measure distribution shift between labeled and unlabeled data
- identify which unlabeled samples are most distant from the labeled set
- guide annotation toward the most impactful sentences
- fits naturally into the active learning cycle

- added WaX computation task
- added api endpoints for Wax
- added a  visualization component in the MulticlassMangement.tsx componenet


NB : Please Check for api endpoint conflicts