### PR TITLE
Refactor/project creation

### DIFF
--- a/api/activetigger/app/routers/projects.py
+++ b/api/activetigger/app/routers/projects.py
@@ -213,15 +213,57 @@ def add_testdata(
     try:
         if evalset is None:
             raise Exception("No evalset sent")
-        project.add_evalset(dataset, evalset, current_user.username, project.project_slug)
+        #project.add_evalset(dataset, evalset, current_user.username, project.project_slug)
+        existing=next((t for t in project.computing if t.kind == "add_eval_set" and t.status=="adding"),None)
+        if existing:
+            return {
+                "status": "adding",
+                "task_id": existing.unique_id,
+                "message": "An evaluation set is already being imported for this project"
+            }
+        task_id=project.adding_evalset(dataset,evalset,current_user.username,project.project_slug)
         orchestrator.log_action(
             current_user.username, f"ADD EVALSET {dataset}", project.project_slug
         )
-        return None
+        return task_id
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e)) from e
-
-
+    
+@router.get("/projects/evalset/task/{task_id}", dependencies=[Depends(verified_user)])
+async def get_evalset_status(
+    project: Annotated[Project, Depends(get_project)], 
+    task_id: str
+) -> dict:
+    """
+    Get the status of an evaluation set import task
+    """
+    #print('task_id',task_id)
+    task=next((t for t in project.computing if t.kind == "add_eval_set" and t.unique_id==task_id), None)
+    #print("task is ",task)
+    if task is None:
+        return {"status": "not_found", "message": "Task not found in queue"}
+    if task.status=="error":
+        if task.future.exception():
+            return {"status":"error","message":f"Failed{str(task.future.exception())}"}
+        else:
+            try:
+                results=task.future.result()
+                Warnings=results.get("warnings", [])
+                print(Warnings)
+                return {"status":"added","message":"Done","warning":Warnings}
+            except Exception as e:
+                return {"status": "error", "message": f"failed: {str(e)}"}
+    if task.status == "added":
+        warnings = getattr(task, 'warnings', [])
+        return {"status": "added","message": "Done","warning": warnings}
+    return {"status": "adding","message": "Uploading The new Evaluation set ..."}    
+@router.delete("/projects/evalset/task/{task_id}", dependencies=[Depends(verified_user)])
+def cancel_evalset_task(project: Annotated[Project, Depends(get_project)],task_id: str,) -> dict:
+    entry = next((t for t in project.computing if t.unique_id == task_id and t.kind=="add_eval_set"), None)
+    if entry is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+    entry.status = "cancel"
+    return {"status": "cancel", "task_id": task_id}  
 @router.get("/projects")
 def get_projects(
     current_user: Annotated[UserInDBModel, Depends(verified_user)],

--- a/api/activetigger/datamodels.py
+++ b/api/activetigger/datamodels.py
@@ -1,7 +1,7 @@
 import datetime
 from enum import Enum, StrEnum
 from pathlib import Path
-from typing import Any, Callable, Literal, Optional
+from typing import Any, Callable, Literal, Optional,List
 
 from pandas import DataFrame  # type: ignore[import]
 from pydantic import BaseModel, ConfigDict  # for dataframe
@@ -79,13 +79,21 @@ class ProjectBaseModel(BaseModel):
     n_total: int | None = None
     clear_test: bool = False
     clear_valid: bool = False
-    random_selection: bool = False
+    #random_selection: bool = False
+    train_selection: Literal['random', 'stratify', 'sequential', 'force_label'] = 'random'
+    holdout_selection: Optional[Literal['random', 'stratify']] = None
     cols_stratify: list[str] = []
-    stratify_train: bool = False
-    stratify_test: bool = False
-    force_label: bool = False
+    #stratify_train: bool = False
+    #stratify_test: bool = False
+    #force_label: bool = False
     force_computation: bool = False
+    #detect_candidates_col:bool =False
+    start_index_val: int | None = None
+    start_index_test: int | None = None
+    num_rows_val:int|None=None
+    num_rows_test:int|None=None
     seed: int = 42
+
 
 
 class ProjectModel(ProjectBaseModel):
@@ -1127,6 +1135,7 @@ class ProjectCreatingModel(BaseModel):
     status: str
 
 
+
 class TopicsOutModel(BaseModel):
     Topic: int
     Name: str
@@ -1219,3 +1228,32 @@ class BertopicProjectionData(BaseModel):
 
     nodes: list[BertopicProjectionNode]
     cluster_id_label_mapper: dict
+
+class compute_waxModel(BaseModel):
+    """
+    The returned data after Wasserstein distance computaion using source and target datasets
+    """
+    source_texts: List[str]
+    target_texts: List[str]
+    model: str = "all-MiniLM-L6-v2"
+    p: int = 2
+    q: int = 2
+    alpha: int = 2
+    beta: int = 2
+    n: int = 100
+    reg: float = 0.01
+    r: int = 4
+    C: int = 3
+    lr: float = 0.01
+    n_iter: int = 200
+
+#class Wax_computeProjectStateModel:
+
+class AddingEvalsetModel(BaseModel):
+    project_slug: str
+    user: str
+    unique_id: str
+    time: datetime.datetime
+    kind: str
+    status: str
+    warnings: list[str] = []

--- a/api/activetigger/project.py
+++ b/api/activetigger/project.py
@@ -50,9 +50,17 @@ from activetigger.datamodels import (
     QuickModelInModel,
     StaticFileModel,
     UpdateComputing,
+    AddingEvalsetModel,
 )
 from activetigger.db.manager import DatabaseManager
 from activetigger.features import Features
+from activetigger.functions import (
+    clean_regex,
+    get_dir_size,
+    regex_contains,
+    sanitize_query_expression,
+    slugify,
+)
 from activetigger.functions import (
     clean_regex,
     get_dir_size,
@@ -69,6 +77,7 @@ from activetigger.queue_manager import Queue
 from activetigger.quickmodels import QuickModels
 from activetigger.schemes import Schemes
 from activetigger.tasks.create_project import CreateProject
+from activetigger.tasks.add_evalset import AddEvalsets
 from activetigger.tasks.generate_call import GenerateCall
 from activetigger.tasks.update_datasets import UpdateDatasets
 from activetigger.users import Users
@@ -280,6 +289,7 @@ class Project:
 
         # Update the register
         self.computing.append(
+            
             ProjectCreatingModel(
                 username=username,
                 project_slug=self.project_slug,
@@ -433,122 +443,245 @@ class Project:
         self.features.reset_features_file()
         self.quickmodels.drop_models(which="all")
 
-    def add_evalset(
-        self, dataset, evalset: EvalSetDataModel, username: str, project_slug: str
-    ) -> None:
-        """
-        Add a eval dataset (test or valid)
+    # def add_evalset(
+    #     self, dataset, evalset: EvalSetDataModel, username: str, project_slug: str
+    # ) -> None:
+    #     """
+    #     Add a eval dataset (test or valid)
 
-        The eval dataset should :
-        - not contains NA
-        - have a unique id different from the complete dataset
+    #     The eval dataset should :
+    #     - not contains NA
+    #     - have a unique id different from the complete dataset
+    #     - No overlap with trainset
 
-        The id will be modified to indicate imported
+    #     The id will be modified to indicate imported
 
-        TODO : put this task in the queue
+    #     TODO : put this task in the queue
+        
+    #     """
+    #     #### Addition :
+    #     # 1- add overlap verification 
+    #     # 3- ID columns is valid/unique
+    #     # 4- No duplicate IDs within the eval set
+    #     ###################
+        
+    #     if len(evalset.cols_text) == 0:
+    #         raise Exception("No text column selected for the evalset")
+    #     if self.params.dir is None:
+    #         raise Exception("Cannot add eval data without a valid dir")
+    #     if evalset.col_label == "":
+    #         evalset.col_label = None
+    #     if dataset not in ["test", "valid"]:
+    #         raise Exception("Dataset should be test or valid")
+    #     if dataset == "test" and self.params.test:
+    #         raise Exception("There is already a test dataset")     
+    #     if dataset == "valid" and self.params.valid:
+    #         raise Exception("There is already a valid dataset")
+    #     ###--------Importing the CSV File
+    #     csv_buffer = io.StringIO(evalset.csv)
+    #     try:
+    #         df = pd.read_csv(
+    #             csv_buffer,
+    #             dtype={evalset.col_id: str, **{col: str for col in evalset.cols_text}},
+    #             nrows=evalset.n_eval,
+    #         )
+    #     #the CSV file parsing error is now caught
+    #     except Exception as e:
+    #         raise Exception(f"Can't Parse the CSV File :{e}")
+    #     #Suppose the  File is empty 
+    #     if len(df) == 0:
+    #         raise Exception("The Chosen Evaluation Set is Empty")
+    #     if len(df) > 10000:
+    #         raise Exception(f"The Evaluation set is too large : {len(df)} rows > 10^4 ")
+    #     #======UniqueId=====
+    #     if df[evalset.col_id].isnull().any():
+    #         raise Exception("The Column of ID contains Null values")
+    #     n_dup=df[evalset.col_id].duplicated()
+    #     if n_dup.any():
+    #         raise Exception (f"Columns ID has {n_dup.sum()} duplicates")   
+    #     # create text column
+    #     df["text"] = df[evalset.cols_text].apply(
+    #         lambda x: "\n\n".join([str(i) for i in x if pd.notnull(i)]), axis=1
+    #     )
+    #     #So Before changin the Name we will check for overlaps:
+    #     try :
+    #         train_ids=set(
+    #             self.data.get_dataset("train").index.astype(str)
+    #             .map(slugify)
+    #             )
+    #         eval_id=set(df[evalset.col_id].astype(str).map(slugify))
+    #         ovelaps=train_ids.intersection(eval_id)
+    #         if ovelaps:
+    #             raise Exception(f"{len(ovelaps)} evalID(s) already existi in the trainset"
+    #                             f"Please ensure they re disjoint")
+    #     except Exception as e:
+    #         #The overlap error is hard failure since both the new eval set and train set
+    #         #both contains any|all same values 
+    #         if "evalID(s) already existi in the trainset" in str(e):#the sentence use in the error of overlap
+    #             raise
+    #         print(f"can't run ovelap check : {e}") 
+    #     # Between raising Error Or warning : If Error -> would create a design default , if warning this will keeep the app working 
+    #     # So in this case we will either drop overlps or give user chance to change eval set
+    #     # Now change names
+    #     if not evalset.col_label:
+    #         df = df.rename(columns={evalset.col_id: "id"})
+    #     else:
+    #         df = df.rename(
+    #             columns={
+    #                 evalset.col_id: "id",
+    #                 evalset.col_label: "label",
+    #             }
+    #         )
+    #         df["label"] = df["label"].apply(lambda x: str(x) if pd.notna(x) else None)
+    #     # deal with non-unique id
+    #     # compare with the general dataset
+    #     # check overlpas between Train and evaluation set is done before Renaming
+    #     df["id_external"] = df["id"].apply(str)
+    #     if not ((df["id"].astype(str).apply(slugify)).nunique() == len(df)):
+    #         df["id"] = [str(i) for i in range(len(df))]
+    #         print("ID not unique, changed to default id")
+    #     # identify the dataset as imported and set the id
+    #     df["id"] = df["id"].apply(lambda x: f"imported-{str(x)}")
+    #     df = df.set_index("id")
 
-        """
-        if len(evalset.cols_text) == 0:
-            raise Exception("No text column selected for the evalset")
+    #     # import labels if specified + scheme // check if the labels are in the scheme
+    #     if evalset.col_label and evalset.scheme:
+    #         # Check the label columns if they match the scheme or raise error
+    #         scheme = self.schemes.available()[evalset.scheme].labels
+    #         for label in df["label"].dropna().unique():
+    #             if label not in scheme:
+    #                 raise Exception(f"Label {label} not in the scheme {evalset.scheme}")
 
-        if self.params.dir is None:
-            raise Exception("Cannot add eval data without a valid dir")
+    #         elements = [
+    #             {"element_id": element_id, "annotation": label, "comment": ""}
+    #             for element_id, label in df["label"].dropna().items()
+    #         ]
+    #         self.db_manager.projects_service.add_annotations(
+    #             dataset=dataset,
+    #             user_name=username,
+    #             project_slug=project_slug,
+    #             scheme=evalset.scheme,
+    #             elements=elements,
+    #         )
+    #         print("Valid labels imported")
 
-        if evalset.col_label == "":
-            evalset.col_label = None
+    #     # write the dataset
+    #     if dataset == "test":
+    #         df[["id_external", "text"]].to_parquet(self.params.dir.joinpath(config.test_file))
+    #         self.params.test = True
+    #         self.data.load_dataset("test")
+    #         self.params.n_test=len(df)
+    #     elif dataset == "valid":
+    #         df[["id_external", "text"]].to_parquet(self.params.dir.joinpath(config.valid_file))
+    #         self.params.valid = True
+    #         self.data.load_dataset("valid")
+    #         self.params.n_valid=len(df)
+    #     # else:
+    #     #     raise Exception("Dataset should be test or valid")
+    #     # Lines[460-467] already dealt with it 
 
-        if dataset not in ["test", "valid"]:
-            raise Exception("Dataset should be test or valid")
+    #     # update the database
+    #     self.db_manager.projects_service.update_project(
+    #         self.params.project_slug, jsonable_encoder(self.params)
+    #     )
 
-        if dataset == "test" and self.params.test:
-            raise Exception("There is already a test dataset")
-
-        if dataset == "valid" and self.params.valid:
-            raise Exception("There is already a valid dataset")
-
-        csv_buffer = io.StringIO(evalset.csv)
-        df = pd.read_csv(
-            csv_buffer,
-            dtype={evalset.col_id: str, **{col: str for col in evalset.cols_text}},
-            nrows=evalset.n_eval,
-        )
-
-        if len(df) > 10000:
-            raise Exception("You valid set is too large")
-
-        # create text column
-        df["text"] = df[evalset.cols_text].apply(
-            lambda x: "\n\n".join([str(i) for i in x if pd.notnull(i)]), axis=1
-        )
-
-        # change names
-        if not evalset.col_label:
-            df = df.rename(columns={evalset.col_id: "id"})
-        else:
-            df = df.rename(
-                columns={
-                    evalset.col_id: "id",
-                    evalset.col_label: "label",
-                }
-            )
-            df["label"] = df["label"].apply(lambda x: str(x) if pd.notna(x) else None)
-
-        # deal with non-unique id
-        # TODO : compare with the general dataset
-        df["id_external"] = df["id"].apply(str)
-        if not ((df["id"].astype(str).apply(slugify)).nunique() == len(df)):
-            df["id"] = [str(i) for i in range(len(df))]
-            print("ID not unique, changed to default id")
-
-        # identify the dataset as imported and set the id
-        df["id"] = df["id"].apply(lambda x: f"imported-{str(x)}")
-        df = df.set_index("id")
-
-        # import labels if specified + scheme // check if the labels are in the scheme
-        if evalset.col_label and evalset.scheme:
-            # Check the label columns if they match the scheme or raise error
-            scheme = self.schemes.available()[evalset.scheme].labels
-            for label in df["label"].dropna().unique():
-                if label not in scheme:
-                    raise Exception(f"Label {label} not in the scheme {evalset.scheme}")
-
-            elements = [
-                {"element_id": element_id, "annotation": label, "comment": ""}
-                for element_id, label in df["label"].dropna().items()
-            ]
-            self.db_manager.projects_service.add_annotations(
-                dataset=dataset,
-                user_name=username,
-                project_slug=project_slug,
-                scheme=evalset.scheme,
-                elements=elements,
-            )
-            print("Valid labels imported")
-
-        # write the dataset
-        if dataset == "test":
-            df[["id_external", "text"]].to_parquet(self.params.dir.joinpath(config.test_file))
-            self.params.test = True
-            self.data.load_dataset("test")
-        elif dataset == "valid":
-            df[["id_external", "text"]].to_parquet(self.params.dir.joinpath(config.valid_file))
-            self.params.valid = True
-            self.data.load_dataset("valid")
-        else:
-            raise Exception("Dataset should be test or valid")
-
-        # update the database
-        self.db_manager.projects_service.update_project(
-            self.params.project_slug, jsonable_encoder(self.params)
-        )
-
-        # reset the features file
-        self.features.reset_features_file()
-        self.quickmodels.drop_models(which="all")
+    #     # reset the features file
+    #     self.features.reset_features_file()
+    #     self.quickmodels.drop_models(which="all")
 
         # reload the data
-        self.data.load_dataset(dataset)
-
+        #self.data.load_dataset(dataset)
+    def adding_evalset(self,
+                       dataset:str,
+                       evalset:EvalSetDataModel,
+                       username:str,
+                       project_slug:str,
+                       )->str:
+        # train_indexes=list(
+        #     self.data.train.index.astype(str)
+        # ) if self.data.train is not None else []
+        if self.data.train is None:
+            raise Exception("No train data available") # -> although this scenario is out of reach but why not 
+        train_indexes=list(
+            self.data.train.index.astype(str)
+        )
+        scheme=self.schemes.available()[evalset.scheme].labels
+        unique_id=self.queue._add_task(
+            "add_eval_set",
+            self.project_slug,
+            AddEvalsets(
+                project=self.params,
+                dataset=dataset,
+                evalset=evalset,
+                username=username,
+                project_slug=project_slug,
+                train_index=train_indexes,
+                scheme=scheme,
+            ),
+            queue="cpu",
+        )
+        print(f"unique_di is {unique_id}")
+        try:
+            self.computing.append(
+                AddingEvalsetModel(
+                    user=username,
+                    project_slug=self.project_slug,
+                    unique_id=unique_id,
+                    time=datetime.now(timezone.utc),
+                    kind="add_eval_set",
+                    status="adding",   
+                )
+            )
+            #print(f"Added task {unique_id} to computing listnow, {len(self.computing)} tasks")
+        except Exception as e:
+            raise Exception(f"Errror {e}")
+            
+        return unique_id
+    
+    def finish_adding_evalset(self,un_id:str)->None:
+        """
+        This Func called once the evaleset starts adding  
+        """
+        task=self.queue.get(un_id)
+        if task is None:
+            raise Exception (f"Task {un_id} is not Found in the queue")
+        if task.future is None:
+            raise Exception (f"Task {un_id} has no Future")
+        entry=next((c for c in self.computing if c.unique_id==un_id),None)
+        exce=task.future.exception()
+        if exce is not None:
+            if entry:
+                entry.status="error"
+            raise Exception(f"evaluation set import has failed :( :{exce})")
+        res=task.future.result()
+        # in case user cancelled the adding of the file
+        if entry.status=="cancel":
+            print("it is cancelled")
+            self.clean_process(entry)
+            return
+        #--
+        self.params=res["project_params"]
+        self.db_manager.projects_service.update_project(
+            self.project_slug,jsonable_encoder(self.params)
+        )
+        if res["elements"] and res["scheme"]:
+            self.db_manager.projects_service.add_annotation(
+                dataset=res["dataset"],
+                user_name=res["username"],
+                project_slug=res["project_slug"],
+                scheme=res["scheme"],
+                elements=res["elements"],
+            )
+        #print(entry.status)      
+        self.features.reset_features_file()
+        self.quickmodels.drop_models(which="all")    
+        if entry:
+            entry.warnings = res.get("warnings", [])
+            #print("warnings",entry.warnings)
+            entry.status="added"
+            #self.queue.delete(un_id)
+                     
+        
     def train_quickmodel(
         self,
         quickmodel: QuickModelInModel,
@@ -629,6 +762,7 @@ class Project:
             balance_classes=quickmodel.balance_classes or False,
             exclude_labels=quickmodel.exclude_labels,
             test_size=quickmodel.test_size,
+            test_size=quickmodel.test_size,
             retrain=retrain,
             texts=self.data.train["text"] if self.data.train is not None else None,
         )
@@ -657,7 +791,7 @@ class Project:
             cv10=model.cv10,
             balance_classes=model.balance_classes,
             exclude_labels=model.exclude_labels,
-            test_size=model.test_size,
+            test_size=model.test_size
         )
         self.train_quickmodel(quickmodel, username, retrain=True)
 
@@ -707,6 +841,7 @@ class Project:
         - fixed
         - random
         - active (entropy or active LABEL)
+        - active (entropy or active LABEL)
         - maxprob
         - test
 
@@ -736,6 +871,7 @@ class Project:
         predict = PredictedLabel(label=None, proba=None, entropy=None)
         if next.model_active is not None:
             prediction = self.get_model_prediction(next.model_active.type, next.model_active.value)
+            proba = prediction.reindex(df.index)
             proba = prediction.reindex(df.index)
 
         # filter based on the labels
@@ -783,8 +919,8 @@ class Project:
             df["ID"] = df.index  # duplicate the id column
             filter_san = clean_regex(next.filter)
             if "CONTEXT=" in filter_san:  # case to search in the context
-                f_regex = regex_contains(
-                    df[existing_cols_contexts + ["ID"]].apply(
+              f_regex = regex_contains(
+                  df[existing_cols_contexts + ["ID"]].apply(
                         lambda row: " ".join(row.values.astype(str)), axis=1
                     ),
                     filter_san.replace("CONTEXT=", ""),
@@ -793,13 +929,14 @@ class Project:
                 )
             elif "QUERY=" in filter_san:  # case to use a query
                 query_expr = sanitize_query_expression(
-                    filter_san.replace("QUERY=", ""),
-                    allowed_columns=existing_cols_contexts,
+                filter_san.replace("QUERY=", ""),
+                allowed_columns=existing_cols_contexts,
                 )
                 f_regex = cast(
-                    pd.Series, df[existing_cols_contexts].eval(query_expr)
-                )
+                    pd.Series, df[existing_cols_contexts].eval(query_expr))
+                
             else:
+                f_regex = regex_contains(df["text"], filter_san, case=True, na=False)
                 f_regex = regex_contains(df["text"], filter_san, case=True, na=False)
             f = f & f_regex
 
@@ -832,7 +969,6 @@ class Project:
             )
         indicator = None
         n_sample = f.sum()  # use len(ss) for adding history
-
         # validate selection method
         valid_selections = {"fixed", "random", "maxprob", "active"}
         if next.selection not in valid_selections:
@@ -840,7 +976,7 @@ class Project:
 
         # select an element based on the method
 
-        if next.selection == "fixed":  # next row
+        elif next.selection == "fixed":  # next row
             element_id = ss.index[0]
 
         elif next.selection == "random":  # random row
@@ -853,18 +989,45 @@ class Project:
         # maxprob: highest probability for a specific label
         if next.selection == "maxprob" and proba is not None:
             if next.label_prob is None:
-                raise Exception("Label is required for maxprob selection")
+                raise Exception("Label for maxprob is required")
             ss = (
                 proba[f][next.label_prob]
                 .drop(next.history, errors="ignore")
                 .sort_values(ascending=False)
-            )
+            ) 
             element_id = ss.index[0]
             n_sample = f.sum()
             indicator = f"probability: {round(proba.loc[element_id, next.label_prob], 2)}"
 
         # active: two modes depending on whether label_prob is set
+        # active: two modes depending on whether label_prob is set
         if next.selection == "active" and proba is not None:
+            if next.label_prob is not None:
+                # active LABEL: filter to texts predicted as label, sort by ascending prob
+                f_predicted = proba["prediction"] == next.label_prob
+                f_active = f & f_predicted
+                if f_active.sum() == 0:
+                    raise ValueError(
+                        f"No element predicted as '{next.label_prob}' available."
+                    )
+                ss_active = (
+                    proba[f_active][next.label_prob]
+                    .drop(next.history, errors="ignore")
+                    .sort_values(ascending=True)
+                )
+                element_id = ss_active.index[0]
+                n_sample = f_active.sum()
+                indicator = f"probability: {round(proba.loc[element_id, next.label_prob], 2)}"
+            else:
+                # active (no label): higher entropy (uncertainty sampling)
+                ss_active = (
+                    proba[f]["entropy"]
+                    .drop(next.history, errors="ignore")
+                    .sort_values(ascending=False)
+                )
+                element_id = ss_active.index[0]
+                n_sample = f.sum()
+                indicator = f"entropy: {round(proba.loc[element_id, 'entropy'], 2)}"
             if next.label_prob is not None:
                 # active LABEL: filter to texts predicted as label, sort by ascending prob
                 f_predicted = proba["prediction"] == next.label_prob
@@ -1189,6 +1352,8 @@ class Project:
                 methods_min=["fixed", "random"],
                 methods=["fixed", "random", "maxprob", "active"],
                 sample=["untagged", "all", "tagged", "not_by_me", "commented"],
+                methods=["fixed", "random", "maxprob", "active"],
+                sample=["untagged", "all", "tagged", "not_by_me", "commented"],
             ),
             schemes=self.schemes.state(),
             features=self.features.state(),
@@ -1295,7 +1460,6 @@ class Project:
             data = data.dropna(subset=["labels"])
 
         # select columns + order
-        # drop dataset_annotation (redundant with dataset)
         cols_to_drop = [col for col in data.columns if col.endswith("dataset_annotation")]
         data = data.drop(columns=cols_to_drop, errors="ignore")
 
@@ -1391,6 +1555,7 @@ class Project:
             self.params.language = update.language
 
         # for other updates, add task to the queue
+        #change :add_task----> _add_task
         unique_id = self.queue.add_task(
             kind="update_datasets",
             project_slug=self.name,
@@ -1461,6 +1626,7 @@ class Project:
             auto_max_length=bert.auto_max_length,
             class_balance=bert.class_balance,
             class_min_freq=bert.class_min_freq,
+            class_min_freq=bert.class_min_freq,
         )
         self.monitoring.register_process(
             process_name=process_id,
@@ -1511,9 +1677,11 @@ class Project:
         """
         Clean a process from computing and queue
         """
-        self.computing.remove(e)
-        self.queue.delete(e.unique_id)
-
+        #added a safety check HERE
+        if e in self.computing:
+            self.computing.remove(e)
+            self.queue.delete(e.unique_id)
+            
     def update_processes(self) -> None:
         """
         Update completed processes and do specific operations regarding their kind
@@ -1522,7 +1690,7 @@ class Project:
         - manage error if needed
         """
         add_predictions = {}
-
+        delayed_clean=False
         # loop on the current process
         for e in self.computing.copy():
             # get the process
@@ -1649,6 +1817,13 @@ class Project:
                         events = cast(EventsModel, results)
                         self.bertopic.add(bertopic_model)
                         self.monitoring.close_process(bertopic_model.unique_id, events)
+                    case "add_eval_set":
+                        import threading
+                        e=cast(AddingEvalsetModel,e)
+                        self.finish_adding_evalset(e.unique_id)
+                        delayed_clean=True
+                        threading.Timer(10, self.clean_process, args=[e]).start()
+                        
             except Exception as ex:
                 print(f"Error in {e.kind} : {ex}")
                 self.errors.add(f"Error in {e.kind} : {str(ex)}")
@@ -1662,13 +1837,38 @@ class Project:
                         )
             # clean the process from the list and the queue
             finally:
-                self.clean_process(e)
+                if not delayed_clean:
+                    self.clean_process(e)
 
         # if there are predictions, add them
         if len(add_predictions) > 0:
             errors = self.features.add_predictions(add_predictions)
             for err in errors:
                 self.errors.add(err)
+
+    def get_data_s_current_status(self,scheme,dataset):
+        """
+        This Function will enable us to get labled and unlabled data from the corpus
+        one of the uses is to compute the Wasserstein disnatnce using WaX -> U-WaX will be fully 
+        implemented later
+        """
+        availabe_schemes = self.schemes.available()
+        df_scheme=self.schemes.get_scheme(scheme,complete=False,datasets=[dataset])
+        labeled_data=df_scheme[df_scheme['labels'].notna()]#This will serve as source
+        unlabeled_data=df_scheme[df_scheme["labels"].isna()]#this will serve as target
+        if labeled_data.empty or unlabeled_data.empty:
+            return []
+        data_df = getattr(self.data, dataset, None)
+        if data_df is None:
+            raise ValueError(f"No {dataset} dataset available")
+        def to_list(df):
+            if df.empty:
+                return []
+            merged = df.join(data_df[['text']], how='inner')
+            return [{"id": idx, "text": row['text']} for idx, row in merged.iterrows()]
+        return to_list(labeled_data), to_list(unlabeled_data)
+    
+        
 
     # def dump(self, with_files=True) -> None:
     #     """

--- a/api/activetigger/tasks/add_evalset.py
+++ b/api/activetigger/tasks/add_evalset.py
@@ -1,0 +1,202 @@
+from activetigger.tasks.base_task import BaseTask
+from activetigger.datamodels import EvalSetDataModel,ProjectModel
+import pandas as pd
+import io
+from activetigger.functions import slugify
+from fastapi.encoders import jsonable_encoder
+from activetigger.config import config
+
+
+
+
+
+class AddEvalsets(BaseTask):
+    """
+    Class responsable for adding Evalset to the queue
+    Added in the queue
+    
+    """
+    
+    kind="add_eval_set"
+    def __init__(self,
+                 project:ProjectModel,
+                 dataset:str,
+                 evalset:EvalSetDataModel,
+                 username:str,
+                 project_slug:str,
+                 train_index:list[str],
+                 scheme:dict[str,list],
+                 
+                 ):
+        super().__init__()
+        self.project=project
+        self.dataset=dataset
+        self.evalset=evalset
+        self.username=username
+        self.project_slug=project_slug
+        self.train_indexs=train_index
+        self.scheme=scheme
+        self.elements=None
+        self.warnings=[]
+    def _add_evalset(
+        self
+    ) -> None:
+        """
+        Add a eval dataset (test or valid)
+
+        The eval dataset should :
+        - not contains NA
+        - have a unique id different from the complete dataset
+        - No overlap with trainset
+
+        The id will be modified to indicate imported
+
+        #TODO : put this task in the queue -> Done (Please after Approval remove this)
+        
+        """
+        #### Addition :
+        # 1- add overlap verification 
+        # 3- ID columns is valid/unique
+        # 4- No duplicate IDs within the eval set
+        ###################
+        if len(self.evalset.cols_text) == 0:
+            raise Exception("No text column selected for the evalset")
+        if self.project.dir is None:
+            raise Exception("Cannot add eval data without a valid dir")
+
+        if self.evalset.col_label == "":
+            self.evalset.col_label = None
+
+        if self.dataset not in ["test", "valid"]:
+            raise Exception("Dataset should be test or valid")
+
+        if self.dataset == "test" and self.project.test:
+            raise Exception("There is already a test dataset")
+        
+        if self.dataset == "valid" and self.project.valid:
+            raise Exception("There is already a valid dataset")
+        ###--------Importing the CSV File
+        csv_buffer = io.StringIO(self.evalset.csv)
+        try:
+            df = pd.read_csv(
+                csv_buffer,
+                dtype={self.evalset.col_id: str, **{col: str for col in self.evalset.cols_text}},
+                nrows=self.evalset.n_eval,
+            )
+        #the CSV file parsing error is now caught
+        except Exception as e:
+            raise Exception(f"Can't Parse the CSV File :{e}")
+        #Suppose the  File is empty 
+        if len(df) == 0:
+            raise Exception("The Chosen Evaluation Set is Empty")
+        if len(df) > 10000:
+            raise Exception(f"The Evaluation set is too large : {len(df)} rows > 10^4 ")
+        #======UniqueId=====
+        if df[self.evalset.col_id].isnull().any():
+            raise Exception("The Column of ID contains Null values")
+        n_dup=df[self.evalset.col_id].duplicated()
+        if n_dup.any():
+            raise Exception (f"Columns ID has {n_dup.sum()} duplicates")   
+        # create text column
+        df["text"] = df[self.evalset.cols_text].apply(
+            lambda x: "\n\n".join([str(i) for i in x if pd.notnull(i)]), axis=1
+        )
+        #So  we will check for overlaps:
+        try :
+            train_ids=set(map(slugify,self.train_indexs))
+            eval_id=set(df[self.evalset.col_id].astype(str).map(slugify))
+            ovelaps=train_ids.intersection(eval_id)
+            if ovelaps:
+                self.warnings.append(
+                    f"{len(ovelaps)} eval ID(s) already exist in the train set — "
+                    f"data leakage risk, metrics may be unreliable. "
+                    f"Examples: {list(ovelaps)[:3]}"
+                )
+        except Exception as e:
+            #The overlap error is hard failure since both the new eval set and train set
+            #both contains any|all same values 
+            if "evalID(s) already existi in the trainset" in str(e):#the sentence use in the error of overlap
+                raise
+            print(f"can't run ovelap check : {e}") 
+        # Between raising Error Or warning : If Error -> would create a design default , if warning this will keeep the app working 
+        # So in this case we will either drop overlps or give user chance to change eval set
+        # Now change names
+        if not self.evalset.col_label:
+            df = df.rename(columns={self.evalset.col_id: "id"})
+        else:
+            df = df.rename(
+                columns={
+                    self.evalset.col_id: "id",
+                    self.evalset.col_label: "label",
+                }
+            )
+            df["label"] = df["label"].apply(lambda x: str(x) if pd.notna(x) else None)
+        # deal with non-unique id
+        # compare with the general dataset
+        # check overlpas between Train and evaluation set is done before Renaming
+        df["id_external"] = df["id"].apply(str)
+        if not ((df["id"].astype(str).apply(slugify)).nunique() == len(df)):
+            df["id"] = [str(i) for i in range(len(df))]
+            print("ID not unique, changed to default id")
+        # identify the dataset as imported and set the id
+        df["id"] = df["id"].apply(lambda x: f"imported-{str(x)}")
+        df = df.set_index("id")
+        #elements = None
+        # import labels if specified + scheme // check if the labels are in the scheme
+        if self.evalset.col_label and self.evalset.scheme:
+            # Check the label columns if they match the scheme or raise error
+            #scheme = self.schemes.available()[self.evalset.scheme].labels
+            for label in df["label"].dropna().unique():
+                if label not in self.scheme:
+                    raise Exception(f"Label {label} not in the scheme {self.evalset.scheme}")
+
+            self.elements = [
+                {"element_id": element_id, "annotation": label, "comment": ""}
+                for element_id, label in df["label"].dropna().items()
+            ]
+            #This is annotation 
+            # self.project.db_manager.projects_service.add_annotations(
+            #     dataset=dataset,
+            #     user_name=username,
+            #     project_slug=project_slug,
+            #     scheme=evalset.scheme,
+            #     elements=elements,
+            # )
+            # print("Valid labels imported")
+
+        # write the dataset
+        if self.dataset == "test":
+            df[["id_external", "text"]].to_parquet(self.project.dir.joinpath(config.test_file))
+            self.project.test = True
+            #self.project.data.load_dataset("test")
+            self.project.n_test=len(df)
+        elif self.dataset == "valid":
+            df[["id_external", "text"]].to_parquet(self.project.dir.joinpath(config.valid_file))
+            self.project.valid = True
+            #self.project.data.load_dataset("valid")
+            self.project.n_valid=len(df)
+        # else:
+        #     raise Exception("Dataset should be test or valid")
+        # Lines[460-467] already dealt with it 
+
+        # update the database
+        # self.db_manager.projects_service.update_project(
+        #     self.params.project_slug, jsonable_encoder(self.params)
+        # )
+
+        # # reset the features file
+        # self.project.features.reset_features_file()
+        # self.project.quickmodels.drop_models(which="all")
+        return {
+            "dataset":self.dataset,
+            "n_eval_rows":len(df),
+            "elements":self.elements,
+            "scheme":self.evalset.scheme,
+            "project_params":self.project,
+            "project_slug":self.project_slug,
+            "username":self.username,
+            "warnings":self.warnings,   
+        }
+    def __call__(self):
+        return self._add_evalset()
+        

--- a/api/activetigger/tasks/create_project.py
+++ b/api/activetigger/tasks/create_project.py
@@ -41,14 +41,168 @@ class CreateProject(BaseTask):
         self.test_file = test_file
         self.valid_file = valid_file
         self.features_file = features_file
-
-    def __call__(
+    #===============================================================================================#
+    # Defining 3 Main functions for Now :                   
+    # 1- 'Build test_val" dataset" : responsible for the build of both test / validation dataset(s)
+    # 2- buildtrainset : responsible for building the trainset 
+    # 3- detect labels : this function will automatically catch label cols with no human 
+    #     internvation and give suggestion to use it 
+    # 4- adding WaX /U-WaX ---> 
+    #================================================================================================#
+    # def detect_cols_with_labels(self,dataset:pd.DataFrame)->list:
+    #     """
+    #     """
+    #     empty_cols=[col for col in dataset.columns if dataset[col].isna().any()]
+    #     label_candidates=[col for col in empty_cols if 'label' in col.lower() or 'traget' in col.lower()]
+    #     if not label_candidates and empty_cols:
+    #         label_candidates=[max(empty_cols,key=lambda col : dataset[col].isna().sum())]
+    #     return label_candidates 
+    def build_trainset(self, dataset: pd.DataFrame) -> tuple[pd.DataFrame | None, list]:
+        """
+        Build a Training Set based on all The possible train selection
+        modes taken in count 
+        Returns (trainset,list_of_train_row_indices)
+        """
+        if self.params.n_train<=0:
+            return None,[]
+        trainset=None
+        #========================Sequential train (first N rows)==============================
+        if self.params.train_selection=="sequential":
+            n=min(self.params.n_train,len(dataset))
+            trainset = dataset.iloc[:n].copy()
+        #========================Force label (prioritize already labeled rows)==========================
+        elif self.params.train_selection=="force_label" and self.params.cols_label:
+            col=self.params.cols_label[0]
+            labeled=dataset[dataset[col].notna()]
+            unlabeled=dataset[dataset[col].isna()]
+            if len(labeled) >= self.params.n_train:
+                trainset=labeled.sample(self.params.n_train,random_state=self.random_seed)
+            else:
+                n_random=self.params.n_train-len(labeled)
+                trainset = pd.concat([labeled,unlabeled.sample(n_random, random_state=self.random_seed)], ignore_index=False)
+        #===============================Stratified train======================================================
+        elif len(self.params.cols_stratify)>0 and self.params.train_selection=="stratify":
+            df_grouped=dataset.groupby(self.params.cols_stratify, group_keys=False)
+            nb_cat=len(df_grouped)
+            nb_per_cat=round(self.params.n_train/nb_cat)
+            sampled_idx = df_grouped.apply(
+                lambda x: x.sample(min(len(x), nb_per_cat), random_state=self.random_seed)
+            ).index.get_level_values(-1)
+            trainset = dataset.loc[sampled_idx]
+        #============================Random (default / fallback)====================================================
+        else:
+            self.params.train_selection="random"
+            trainset = dataset.sample(self.params.n_train,random_state=self.random_seed)
+        #====================== SAVE TRAINSET ======================
+        if trainset is not None and len(trainset) > 0:
+            cols_to_save=["id_external", "text"]+self.params.cols_context
+            trainset[cols_to_save].to_parquet(self.params.dir.joinpath(self.train_file),index=True)
+        train_rows=list(trainset.index) if trainset is not None else []
+        print(len(trainset))
+        return trainset, train_rows
+    def build_test_val_set(
         self,
-    ) -> tuple[ProjectModel, pd.DataFrame | None, pd.DataFrame | None, pd.DataFrame | None]:
+        dataset: pd.DataFrame,
+        train_rows: list | None = None,
+        start_index_val: int | None = None,
+        start_index_test: int | None = None,
+    ) -> tuple[pd.DataFrame | None, pd.DataFrame | None, list, list]:
+        """
+        Build valid and test sets with support for explicit start indices(in case of sequential/Determisitic) + overlap protection 
+        """
+        n_test=getattr(self.params, 'n_test', 0)
+        n_val=getattr(self.params, 'n_valid', 0)
+        n_draw=n_test + n_val
+        validset=testset=None
+        rows_valid:list=[]
+        rows_test:list=[]
+        if n_draw == 0:
+            return None, None, [], []
+        # Pool for random/stratified cases (excludes train to prevent leakage)
+        if train_rows:
+            holdout_pool = dataset.drop(index=train_rows)
+            train_idx_set = set(train_rows)
+        else:
+            holdout_pool = dataset.copy()
+            train_idx_set = set()
+        #===================================SEQUENTIAL MODE (holdout_selection is None)=================================
+        if self.params.holdout_selection is None:
+            #Determine start positions
+            start_val=start_index_val if start_index_val is not None else self.params.n_train
+            start_test = start_index_test if start_index_test is not None else (start_val + n_val)
+            #Build Validation
+            if n_val > 0:
+                end_val = start_val + n_val
+                if end_val > len(dataset):
+                    raise Exception(f"Validation slice [{start_val}:{end_val}] out of bounds! "
+                                    f"Dataset has {len(dataset)} rows.")
+                validset = dataset.iloc[start_val:end_val]
+            #Build Test
+            if n_test > 0:
+                end_test = start_test + n_test
+                if end_test > len(dataset):
+                    raise Exception(f"Test slice [{start_test}:{end_test}] out of bounds! "
+                                  f"Dataset has {len(dataset)} rows.")
+                testset = dataset.iloc[start_test:end_test]
+            # ====================== OVERLAP CHECKS ======================
+            valid_idx = set(validset.index) if validset is not None else set()
+            test_idx = set(testset.index) if testset is not None else set()
+            #1er cas : Validation overlaps with Train:
+            if valid_idx & train_idx_set:
+                overlap = len(valid_idx & train_idx_set)
+                raise Exception(f"Validation set overlaps with train by {overlap} rows!")
+            #2eme cas :Test overlaps with Train:
+            if test_idx & train_idx_set:
+                overlap = len(test_idx & train_idx_set)
+                raise Exception(f"Test set overlaps with train by {overlap} rows!")
+            #3eme cas:Test overlaps with Validation:
+            if valid_idx & test_idx:
+                overlap = len(valid_idx & test_idx)
+                raise Exception(f"Test and Validation sets overlap by {overlap} rows!")
+        #=======================================STRATIFIED HOLD OUT========================================
+        elif self.params.holdout_selection == "stratify" and len(self.params.cols_stratify) > 0:
+            if len(holdout_pool) < n_draw:
+                raise Exception(f"Not enough rows for stratified holdout. Need {n_draw}, have {len(holdout_pool)}")
+            df_grouped = holdout_pool.groupby(self.params.cols_stratify, group_keys=False)
+            nb_cat = len(df_grouped)
+            nb_per_cat = max(1, round(n_draw / nb_cat))
+            sampled_idx = df_grouped.apply(lambda x: x.sample(min(len(x), nb_per_cat), random_state=self.random_seed)).index.get_level_values(-1)
+            holdout = holdout_pool.loc[sampled_idx]
+            if n_test > 0 and n_val > 0:
+                testset = holdout.sample(n_test, random_state=self.random_seed)
+                validset = holdout.drop(index=testset.index)
+            elif n_test > 0:
+                testset = holdout
+            else:
+                validset = holdout
+        #===================================RANDOM HOLD OUT (default)===============================================
+        else:
+            if len(holdout_pool) < n_draw:
+                raise Exception(f"Not enough rows for holdout. Need {n_draw}, have {len(holdout_pool)}")
+            holdout = holdout_pool.sample(n_draw, random_state=self.random_seed)
+            if n_test > 0 and n_val > 0:
+                testset = holdout.sample(n_test, random_state=self.random_seed)
+                validset = holdout.drop(index=testset.index)
+            elif n_test > 0:
+                testset = holdout
+            else:
+                validset = holdout
+        # ====================== SAVE TO PARQUET ======================
+        for name, ds, file_attr, flag in [("valid", validset, "valid_file", "valid"),("test",  testset,  "test_file",  "test")]:
+            if ds is not None and len(ds) > 0:
+                ds.to_parquet(self.params.dir.joinpath(getattr(self.params, file_attr)), index=True)
+                setattr(self.params, flag, True)
+                rows = list(ds.index)
+                if name == "valid":
+                    rows_valid = rows
+                else:
+                    rows_test = rows
+        return validset, testset, rows_valid, rows_test
+    def __call__(self) -> tuple[ProjectModel, pd.DataFrame | None, pd.DataFrame | None, pd.DataFrame | None]:
         """
         Create the project with the given name and file
         Define an internal and external index
-        return the project model and the train/valid/test datasets to import in the database
+        Return the project model and the train/valid/test datasets to import in the database
         """
         print(f"Start queue project {self.project_slug} for {self.username}")
         # check if the directory already exists + file (should with the data)
@@ -97,7 +251,7 @@ class CreateProject(BaseTask):
             self.params.cols_label = ["dataset_" + i for i in self.params.cols_label if i]
             self.params.cols_stratify = ["dataset_" + i for i in self.params.cols_stratify if i]
 
-            # remove completely empty lines
+            # remove completely empty lines..
             content = content.dropna(how="all")
 
         # quickfix : case where the index is the row number
@@ -162,122 +316,58 @@ class CreateProject(BaseTask):
         # save a complete copy of the dataset
         content.to_parquet(self.params.dir.joinpath(self.data_all), index=True)
 
-        # ------------------------
+        # -----------------------
         # End of the data cleaning
         # ------------------------
-        # Step 2 : valid/test dataset : from the complete dataset + random/stratification
-        # if both, draw together valid / test set and then separage
-        rows_test = []
-        rows_valid = []
+
+        #====================== SPLITTING LOGIC======================
+        rows_test: list = []
+        rows_valid: list = []
         self.params.test = False
         self.params.valid = False
-        testset = None
+        trainset = None
         validset = None
-
-        # case there is a test or valid set, common draw
-        if self.params.n_test + self.params.n_valid != 0:
-            n_to_draw = self.params.n_test + self.params.n_valid
-            # manage stratification
-            if len(self.params.cols_stratify) == 0:
-                draw = content.sample(n_to_draw, random_state=self.random_seed)
-            else:
-                df_grouped = content.groupby(self.params.cols_stratify, group_keys=False)
-                nb_cat = len(df_grouped)
-                nb_elements_cat = round(n_to_draw / nb_cat)
-                sampled_idx = df_grouped.apply(
-                    lambda x: x.sample(min(len(x), nb_elements_cat), random_state=self.random_seed)
-                ).index.get_level_values(-1)
-                draw = content.loc[sampled_idx]
-
-            # divide between test and valid
-            if self.params.n_test > 0 and self.params.n_valid == 0:
-                testset = draw
-                testset.to_parquet(self.params.dir.joinpath(self.test_file), index=True)
-                self.params.test = True
-                rows_test = list(testset.index)
-            elif self.params.n_valid > 0 and self.params.n_test == 0:
-                validset = draw
-                validset.to_parquet(self.params.dir.joinpath(self.valid_file), index=True)
-                self.params.valid = True
-                rows_valid = list(validset.index)
-            else:
-                testset = draw.sample(self.params.n_test, random_state=self.random_seed)
-                validset = draw.drop(index=testset.index)
-                validset.to_parquet(self.params.dir.joinpath(self.valid_file), index=True)
-                testset.to_parquet(self.params.dir.joinpath(self.test_file), index=True)
-                self.params.test = True
-                self.params.valid = True
-                rows_valid = list(validset.index)
-                rows_test = list(testset.index)
-
-        # Step 3 : train dataset / different strategies
-
-        # remove test rows
-        content = content.drop(rows_test)
-        content = content.drop(rows_valid)
-
-        # case where there is no valid/test set and the selection is deterministic
-        if (
-            not self.params.random_selection
-            and self.params.n_test == 0
-            and self.params.n_valid == 0
-        ):
-            trainset = content[0 : self.params.n_train]
-        # case to force the max of label from one column
-        elif self.params.force_label and len(self.params.cols_label) > 0:
-            f_notna = content[self.params.cols_label[0]].notna()
-            f_na = content[self.params.cols_label[0]].isna()
-            # different case regarding the number of labels
-            if f_notna.sum() > self.params.n_train:
-                trainset = content[f_notna].sample(
-                    self.params.n_train, random_state=self.random_seed
-                )
-            else:
-                n_train_random = self.params.n_train - f_notna.sum()
-                trainset = pd.concat(
-                    [
-                        content[f_notna],
-                        content[f_na].sample(n_train_random, random_state=self.random_seed),
-                    ]
-                )
-        # case there is stratification on the trainset
-        elif len(self.params.cols_stratify) > 0 and self.params.stratify_train:
-            df_grouped = content.groupby(self.params.cols_stratify, group_keys=False)
-            nb_cat = len(df_grouped)
-            nb_elements_cat = round(self.params.n_train / nb_cat)
-            sampled_idx = df_grouped.apply(
-                lambda x: x.sample(min(len(x), nb_elements_cat), random_state=self.random_seed)
-            ).index.get_level_values(-1)
-            trainset = content.loc[sampled_idx]
-        # default with random selection in the remaining elements
+        testset = None
+        #=====================================================================
+        # Sequential train → build train first, then holdout from remaining
+        #====================================================================
+        if self.params.train_selection == "sequential":
+            trainset, train_rows = self.build_trainset(content)
+            validset, testset, rows_valid, rows_test = self.build_test_val_set(
+                dataset=content,
+                train_rows=train_rows,
+                start_index_val=getattr(self.params, 'start_index_val', None),
+                start_index_test=getattr(self.params, 'start_index_test', None),
+            )
+        #========================================================================
+        # Non-sequential (random/stratify/force_label) → build holdout first
+        #=======================================================================
         else:
-            trainset = content.sample(self.params.n_train, random_state=self.random_seed)
-
-        # write the trainset
-        trainset[["id_external", "text"] + self.params.cols_context].to_parquet(
-            self.params.dir.joinpath(self.train_file), index=True
-        )
-
-        # save parameters (without the data)
+            # Build holdout on full data
+            validset, testset, rows_valid, rows_test = self.build_test_val_set(content)
+            # Then build train on the remaining rows
+            excluded_idx = set(rows_valid + rows_test)
+            remaining = content.drop(index=list(excluded_idx)) if excluded_idx else content
+            trainset, _ = self.build_trainset(remaining)
+        #====================== SAVE PARAMETERS & LABELS ======================
+        #save parameters
         project = self.params.model_dump()
-
         # add elements for the parameters
         project["project_slug"] = self.project_slug
         project["all_columns"] = all_columns
         project["n_total"] = n_total
-
-        # schemes/labels to import (in the main process)
+        # schemes/labels to import
         import_trainset = None
         import_testset = None
         import_validset = None
         if len(self.params.cols_label) > 0:
-            import_trainset = trainset[self.params.cols_label].dropna(how="all")
-            if testset is not None and not self.params.clear_test:
+            if trainset is not None:
+                import_trainset = trainset[self.params.cols_label].dropna(how="all")
+            if testset is not None and not getattr(self.params, 'clear_test', False):
                 import_testset = testset[self.params.cols_label].dropna(how="all")
-            if validset is not None and not self.params.clear_valid:
+            if validset is not None and not getattr(self.params, 'clear_valid', False):
                 import_validset = validset[self.params.cols_label].dropna(how="all")
-
-        # delete the initial file
+        # delete the initial uploaded file
         if self.params.filename is not None:
             try:
                 self.params.dir.joinpath(self.params.filename).unlink()

--- a/frontend/src/components/ProjectParameters.tsx
+++ b/frontend/src/components/ProjectParameters.tsx
@@ -37,28 +37,43 @@ export const ProjectParameters: FC<ProjectParametersModel> = ({ project, project
 
       <ModelParametersTab
         params={
-          {
-            'Project Name': project.params.project_name,
-            'Project Slug': project.params.project_slug,
-            Filename: project.params.filename,
-            'Total Rows': project.params.n_total,
-            Language: project.params.language,
-            'Text Column': project.params.cols_text,
-            'Column ID': project.params.col_id,
-            'Colums context': project.params.cols_context,
-            'Rows in train set': project.params.n_train,
-            'Rows in test set': project.params.test ? project.params.n_test : 'Empty',
-            'Rows in valid set': project.params.valid ? project.params.n_valid : 'Empty',
-            'Stratify train set': project.params.stratify_train ? 'Yes' : 'No',
-            'Stratify test set': project.params.stratify_test ? 'Yes' : 'No',
-            'Random Sample': project.params.random_selection ? 'Yes' : 'No',
-            'Stratification columns':
-              project.params.cols_stratify.length > 0
-                ? project.params.cols_stratify.join(', ')
-                : 'None',
-          } as Record<string, unknown>
-        }
-      />
+        {
+          'Project Name': project.params.project_name,
+          Filename: project.params.filename ?? 'N/A',
+          Language: project.params.language,
+          'Text Columns': Array.isArray(project.params.cols_text)
+            ? project.params.cols_text.join(', ')
+            : project.params.cols_text,
+          'Column ID': project.params.col_id,
+          'Context Columns':
+            project.params.cols_context.length > 0
+              ? project.params.cols_context.join(', ')
+              : 'None',
+          'Label Columns':
+            project.params.cols_label.length > 0
+              ? project.params.cols_label.join(', ')
+              : 'None',
+          'Total Rows': project.params.n_total ?? 'N/A',
+          'Rows in train set': project.params.n_train,
+          'Rows in test set': project.params.test ? project.params.n_test : 'Empty',
+          'Rows in valid set': project.params.valid ? project.params.n_valid : 'Empty',
+          'Skipped Rows': project.params.n_skip,
+          'Train Selection': project.params.train_selection,
+          'Holdout Selection': project.params.holdout_selection ?? 'None',
+          'Stratification Columns':
+            project.params.cols_stratify.length > 0
+              ? project.params.cols_stratify.join(', ')
+              : 'None',
+          'From Project': project.params.from_project ?? 'None',
+          'From Toy Dataset': project.params.from_toy_dataset ? 'Yes' : 'No',
+          'Embeddings':
+            project.params.embeddings.length > 0
+              ? project.params.embeddings.join(', ')
+              : 'None',
+          Seed: project.params.seed,
+        } as Record<string, unknown>
+      }
+            />
       <Modal show={showModify} onHide={() => setShowModify(false)} id="addfeature-modal">
         <Modal.Header closeButton>
           <Modal.Title>Change project parameters</Modal.Title>

--- a/frontend/src/components/forms/EvalSetsManagement.tsx
+++ b/frontend/src/components/forms/EvalSetsManagement.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from 'react';
+import { FC, useEffect, useState ,useRef } from 'react';
 import DataTable from 'react-data-table-component';
 import { Controller, SubmitHandler, useForm, useWatch } from 'react-hook-form';
 import Select from 'react-select';
@@ -12,6 +12,7 @@ import { loadFile } from '../../core/utils';
 import { Modal } from 'react-bootstrap';
 import { useNavigate } from 'react-router-dom';
 import { EvalSetModel } from '../../types';
+import { useEvalSetStatus } from '../../core/api';
 
 // format of the data table
 export interface DataType {
@@ -25,6 +26,7 @@ export interface EvalSetsManagementModel {
   currentScheme: string;
   dataset: string;
   exist: boolean;
+  task_id:string;
 }
 
 // component
@@ -33,16 +35,18 @@ export const EvalSetsManagement: FC<EvalSetsManagementModel> = ({
   currentScheme,
   dataset,
   exist,
+  task_id,
 }) => {
   // form management
   const datasetCleanForPrinting = dataset == 'test' ? 'Test' : 'Validation';
+  const Message1 = task_id==""? "Cancelling ": "Importing";
   const { register, control, handleSubmit, setValue } = useForm<EvalSetModel & { files: FileList }>(
     {
       defaultValues: { scheme: currentScheme },
     },
   );
-
   const createValidSet = useCreateValidSet(); // API call
+  const {pollStatus,cancelTask} = useEvalSetStatus();
   const { notify } = useNotifications();
 
   const dropEvalSet = useDropEvalSet(projectSlug); // API call to drop existing test set
@@ -52,6 +56,10 @@ export const EvalSetsManagement: FC<EvalSetsManagementModel> = ({
 
   const [data, setData] = useState<DataType | null>(null);
   const files = useWatch({ control, name: 'files' });
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [statusMessage, setStatusMessage] = useState('');
+  const [currentTaskId, setCurrentTaskId] = useState<string>(task_id);
+  const pollIntervalRef = useRef<NodeJS.Timeout | null>(null);
   // available columns
   const columns = data?.headers.map((h) => (
     <option key={`${h}`} value={`${h}`}>
@@ -74,8 +82,7 @@ export const EvalSetsManagement: FC<EvalSetsManagementModel> = ({
       });
     }
   }, [files, setValue, notify]);
-
-  // action when form validated
+  useEffect(()=>{return()=>{if (pollIntervalRef.current) clearInterval(pollIntervalRef.current)};},[]);
   const onSubmit: SubmitHandler<EvalSetModel & { files: FileList }> = async (formData) => {
     if (data) {
       if (!formData.col_id || !formData.cols_text || !formData.n_eval) {
@@ -83,19 +90,29 @@ export const EvalSetsManagement: FC<EvalSetsManagementModel> = ({
         return;
       }
       const csv = data ? unparse(data.data, { header: true, columns: data.headers }) : '';
+      setIsProcessing(true);
+      setStatusMessage("Starting Import...")
       formData.scheme = currentScheme;
-      await createValidSet(projectSlug, dataset, {
+      const task=await createValidSet(projectSlug, dataset, {
         ...omit(formData, 'files'),
         csv,
         filename: data.filename,
       });
+      console.log("task is ",task)
+      console.log(task)
+      
+      if (!task) {
+      setIsProcessing(false);
+      return;
+    }
+    setCurrentTaskId(task);
+    pollStatus(projectSlug,task);
     }
   };
 
   const capFirstLetter = (word: string) => {
     return word.charAt(0).toUpperCase() + word.slice(1);
   };
-
   return (
     <div>
       <h4 className="subsection">{capFirstLetter(dataset)} set</h4>
@@ -112,7 +129,28 @@ export const EvalSetsManagement: FC<EvalSetsManagementModel> = ({
 
       {!exist && (
         <form onSubmit={handleSubmit(onSubmit)}>
-          <div className="col-lg-6">
+          <div className="col-lg-6" style={{ position: 'relative',isolation: 'isolate' }}>
+            {isProcessing && (
+              <div style={{position: 'absolute',top: 0,left: 0,right: 0,
+                bottom: 0,
+                backgroundColor: 'rgba(216, 215, 215, 0.95)',
+                zIndex: 9999,
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                borderRadius: '8px'}}>
+                <h5 className="mb-4 text-center">{statusMessage}</h5>
+                <div className="loading" />
+                <p className="text-muted small text-center">
+                  {Message1}{datasetCleanForPrinting.toLowerCase()} set <br />
+                </p>
+                <button type="button" className="btn-submit"   onClick={async () => {await cancelTask(projectSlug, currentTaskId);setCurrentTaskId("");setIsProcessing(false);}}>
+                  Cancel
+                </button>
+              </div>
+              )
+            }
             <div className="explanations">
               No {datasetCleanForPrinting} data set has been created. You can upload a{' '}
               {datasetCleanForPrinting} set. Careful : all features will be dropped and need to be
@@ -182,15 +220,23 @@ export const EvalSetsManagement: FC<EvalSetsManagementModel> = ({
                     <option key="none" value="">
                       No label
                     </option>
-
                     {columns}
                   </select>
                   <label htmlFor="n_test">Number of rows to import</label>
                   <input id="n_test" type="number" {...register('n_eval')} />
 
-                  <button type="submit" className="btn-submit">
+                  {isProcessing ? (
+                      <button 
+                        type="button" 
+                        className="btn-submit" 
+                        disabled
+                        style={{ opacity: 0.7 }}
+                      >
+                        Adding Evaluation Set...
+                      </button>
+                    ) :(<button type="submit" className="btn-submit">
                     Create
-                  </button>
+                  </button>)}
                 </div>
               )
             }

--- a/frontend/src/core/api.ts
+++ b/frontend/src/core/api.ts
@@ -24,6 +24,7 @@ import {
   SupportedAPI,
   TextDatasetModel,
   newBertModel,
+  WaxParams,
 } from '../types';
 import config from './config';
 import { formatApiError, HttpError } from './HTTPError';
@@ -190,6 +191,7 @@ export function useUserProjects() {
       };
     else {
       notify({ type: 'error', message: formatApiError(res.error) });
+      notify({ type: 'error', message: formatApiError(res.error) });
       throw new HttpError(res.response.status, '');
     }
   }, [fetchTrigger]);
@@ -253,18 +255,116 @@ export function useCreateProject() {
 export function useCreateValidSet() {
   const { notify } = useNotifications();
   const createTestSet = useCallback(
-    async (projectSlug: string, dataset: string, testset: EvalSetDataModel) => {
+    async (projectSlug: string, dataset: string, testset: EvalSetDataModel): Promise<string | null> => {
       const res = await api.POST('/projects/evalset/add', {
         params: {
           query: { project_slug: projectSlug, dataset: dataset },
         },
         body: testset,
       });
-      if (!res.error) notify({ type: 'success', message: 'Test data set uploaded!' });
+      //console.log('resdata',res.data)
+      if (res.error) {
+        notify({ type: 'error', message: 'Failed to import the dataset'});
+        return null;
+      }
+      const TaskId=res.data
+      if (!TaskId){
+        notify({
+          type:'error',
+          message:'No id for this task is received from server'
+
+        })
+      }
+      return res.data as string;
     },
-    [notify],
+    [notify]
   );
   return createTestSet;
+}
+
+/**
+ * get "Adding evalset" task status
+ */
+export function useEvalSetStatus() {
+  const { notify } = useNotifications();
+  const pollStatus = useCallback((projectSlug: string,task_id: string,onComplete?: (result: any) => void) => {
+      if (!projectSlug || !task_id) {
+        return;
+      }
+      const interval = setInterval(async () => {
+        try {
+          const res = await api.GET('/projects/evalset/task/{task_id}', {
+            params: {path: { task_id: task_id },
+            query: { project_slug: projectSlug }},
+          });
+          //console.log('get res data:',res.data)
+          if (res.error) {
+            //console.error('Status check failed:', res.error);
+            clearInterval(interval);
+            notify({
+              type: 'error',
+              message: 'Failed to check import status',
+            });
+            return;
+          }
+
+          const status = res.data as any;
+          //console.log(`Evalset status [${task_id}]:`, status.status);
+          if (status.status === 'added') {
+            clearInterval(interval);
+            notify({
+              type: 'success',
+              message: 'Evalset imported successfully!',
+            });
+            if (status.warning.length > 0){
+            status.warning.forEach((element: string) => {
+              notify({
+              type:"warning",
+              message:element,
+            });
+            });
+          }
+            onComplete?.(status);
+          } 
+          else if (status.status === 'error') {
+            clearInterval(interval);
+            notify({
+              type: 'error',
+              message: `Import failed: ${status.message || 'Unknown error'}`,
+            });
+          } 
+          else if (status.status === 'not_found' || status.status === 'cancel') {
+            clearInterval(interval);
+            notify({
+              type: 'warning',
+              message: 'Task not found (it may have expired or finished)',
+            });
+          }
+        } catch (err: any) {
+          //console.error('Polling error:', err);
+          clearInterval(interval);
+          notify({
+            type: 'error',
+            message: 'Error while checking status',
+          });
+        }
+      }, 500);
+      return () => clearInterval(interval);
+    },
+    [notify]);
+    const cancelTask = useCallback(async (projectSlug: string,task_id: string,) => {
+    try {
+      await api.DELETE('/projects/evalset/task/{task_id}', {
+        params: { path: { task_id }, 
+        query: { project_slug: projectSlug } },
+      });
+      //console.log(task_id)
+      notify({ type: 'warning', message: 'Import cancelled' });
+       } catch (err) {
+      notify({ type: 'error', message: 'Failed to cancel import' });
+      }
+  }, [notify]);
+  return { pollStatus,cancelTask };
 }
 
 /**
@@ -400,6 +500,7 @@ export function useProject(projectSlug?: string) {
       });
       if (res.error) {
         notify({ type: 'error', message: formatApiError(res.error) });
+        notify({ type: 'error', message: formatApiError(res.error) });
         return null;
       }
       //return res.data.params;
@@ -530,10 +631,9 @@ export function useAddFeature() {
       featureType: string,
       featureName: string,
       featureUseDefaultName: boolean,
-      featureParameters: Record<string, string | number | undefined> | null,
+      featureParameters: Record<string, string | number > | null,
     ) => {
       if (!featureName) featureName = featureType;
-
       if (featureType && featureParameters && projectSlug) {
         const res = await api.POST('/features/add', {
           params: {
@@ -543,6 +643,11 @@ export function useAddFeature() {
             name: featureName,
             type: featureType,
             parameters: featureParameters,
+              // ? (Object.fromEntries(
+              //     Object.entries(featureParameters).filter(([_, v]) => v !== undefined)
+              //   ) as Record<string, string | number>)
+              // : {},
+              //added this until check out why undefined parameters cause an issue in the backend :AM_Ouer
             use_default_name: featureUseDefaultName,
           },
         });
@@ -1841,12 +1946,12 @@ export function useTableDisagreement(project_slug?: string, scheme?: string, dat
   return {
     tableDisagreement: data ? data.table : null,
     users: data ? data.users : null,
-    agreementStats: data
-      ? {
+     agreementStats: data
+     ? {
           n_total: data.n_total,
           n_agreements: data.n_agreements,
-          n_disagreements: data.n_disagreements,
-          agreement_percentage: data.agreement_percentage,
+          n_disagreements: data.n_disagreements,           
+          agreement_percentage: data.agreement_percentage,      
           cohen_kappa: data.cohen_kappa,
         }
       : null,
@@ -1937,24 +2042,22 @@ export async function deleteGenModel(project: string, modelId: number) {
   const res = await api.DELETE(`/generate/models/{model_id}`, {
     params: { path: { model_id: modelId }, query: { project_slug: project } },
   });
-  if (res.error) console.error(res.error);
-}
-
-export async function fetchOllamaModels(
+  if (res.error) console.error(res.error);}
+  export async function fetchOllamaModels(
   endpoint: string,
-): Promise<Array<{ slug: string; name: string }>> {
-  const baseUrl = config.api.url.replace(/\/+$/, '');
-  const url = `${baseUrl}/generate/ollama/models?endpoint=${encodeURIComponent(endpoint)}`;
-  const auth = JSON.parse(localStorage.getItem('activeTigger.auth') || '{}');
-  const res = await fetch(url, {
-    headers: {
-      ...(auth.access_token ? { Authorization: `Bearer ${auth.access_token}` } : {}),
-    },
-  });
-  if (!res.ok) {
-    const detail = await res.json().catch(() => null);
-    throw new Error(detail?.detail || `HTTP ${res.status}`);
-  }
+  ): Promise<Array<{ slug: string; name: string }>> {
+   const baseUrl = config.api.url.replace(/\/+$/, '');
+   const url = `${baseUrl}/generate/ollama/models?endpoint=${encodeURIComponent(endpoint)}`;
+   const auth = JSON.parse(localStorage.getItem('activeTigger.auth') || '{}');
+   const res = await fetch(url, {
+     headers: {
+       ...(auth.access_token ? { Authorization: `Bearer ${auth.access_token}` } : {}),
+     },
+   });
+   if (!res.ok) {
+     const detail = await res.json().catch(() => null);
+     throw new Error(detail?.detail || `HTTP ${res.status}`);    
+   }
   return res.json();
 }
 
@@ -2879,8 +2982,8 @@ export function useExportTopicsToScheme(projectSlug: string | null) {
 }
 
 /**
- * Hook to export the topics as a feature for quick models
- */
+ * Hook to export the topics as a feature for quick models      
+*/
 export function useExportTopicsToFeature(projectSlug: string | null) {
   const { notify } = useNotifications();
   const exportTopicsToFeature = useCallback(
@@ -2898,6 +3001,7 @@ export function useExportTopicsToFeature(projectSlug: string | null) {
   );
   return exportTopicsToFeature;
 }
+
 
 export function useGetMonitoringMetrics() {
   const [fetchTrigger, setFetchTrigger] = useState<boolean>(false);
@@ -2927,4 +3031,38 @@ export function useGetMonitoringData(kind: string) {
   const reFetch = useCallback(() => setFetchTrigger((f) => !f), []);
 
   return { data: getAsyncMemoData(getMonitoringData) || null, reFetchData: reFetch };
+}
+
+export function useWaxSuggest() {
+  const { notify } = useNotifications();
+const start = useCallback(
+  async (projectSlug: string, scheme: string, dataset: string, params: WaxParams) => {
+    const res = await api.POST('/elements/wax_suggest', {
+      params: { query: { project_slug: projectSlug, scheme, dataset, n: params.n_suggest } },
+      query: {
+        model: params.model,
+        p: params.p, q: params.q,
+        alpha: params.alpha, beta: params.beta,
+        n: params.n, reg: params.reg,
+        r: params.r, C: params.C,
+        lr: params.lr, n_iter: params.n_iter,
+      },
+    });
+    if (res.error) {
+      notify({ type: 'error', message: 'WAX suggestion failed to start' });
+      return null;
+    }
+    return res.data as { task_id: string };
+  },
+  [notify],
+);
+  const poll = useCallback(async (taskId: string) => {
+    if(!taskId) return null;
+    const res = await api.GET('/elements/wax_status/{task_id}', {
+      params: { path: { task_id: taskId }},
+    });
+    if (res.error) return null;
+    return res.data as { status: string; result: any; error: string | null };
+  }, []);
+  return { start, poll };
 }

--- a/frontend/src/styles/_forms.scss
+++ b/frontend/src/styles/_forms.scss
@@ -28,3 +28,764 @@ label {
   color: #9ca3af; // Tailwind's neutral gray tone (lighter)
   margin-bottom: -5px;
 }
+
+/***********/
+/***********/
+/***********/
+//Layout ─────────
+
+.projectcontainer {
+  min-height: 100vh;
+  background-color: #f9fafb;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 3rem 1rem;
+  gap: 1.5rem;
+
+  .projectcard {
+    width: 100%;
+    max-width: 50rem;
+
+    .projectelement {
+      background-color: white;
+      border-radius: 1rem;
+      box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+      border: 1px solid #f3f4f6;
+      padding: 1.5rem;
+      width: 100%;
+    }
+  }
+}
+
+//Typography ─────
+
+.page-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #111827;
+  margin-bottom: 2rem;
+}
+
+//Form layout ────
+
+.project-form {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.form-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+
+  & + .form-section {
+    border-top: 1px solid #f3f4f6;
+    padding-top: 2rem;
+  }
+}
+
+.section-title {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+  margin-bottom: 1rem;
+}
+
+.section-title--mb {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+  margin-bottom: 1.25rem;
+}
+
+.section-title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+
+  .section-title {
+    margin-bottom: 0;
+  }
+}
+
+.help-icon {
+  color: #d1d5db;
+  flex-shrink: 0;
+}
+
+//Labels & Inputs 
+
+.field-label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+  margin-bottom: 0.375rem;
+}
+
+.field-sublabel {
+  display: block;
+  font-size: 0.75rem;
+  color: #6b7280;
+  margin-bottom: 0.25rem;
+}
+
+.field-sublabel__note {
+  color: #9ca3af;
+}
+
+.field-label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.25rem;
+}
+
+.form-input {
+  width: 100%;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  box-sizing: border-box;
+
+  &:focus {
+    border-color: transparent;
+    box-shadow: 0 0 0 2px #60a5fa;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}
+
+.form-select {
+  width: 100%;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  outline: none;
+  background-color: white;
+  transition: box-shadow 0.15s;
+  box-sizing: border-box;
+
+  &:focus {
+    box-shadow: 0 0 0 2px #60a5fa;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}
+
+.field-hint {
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  color: #9ca3af;
+}
+
+.col-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.mode-toggle {
+  display: flex;
+  border-radius: 0.5rem;
+  border: 1px solid #e5e7eb;
+  padding: 0.25rem;
+  background-color: #f9fafb;
+  width: fit-content;
+  margin-bottom: 1.25rem;
+}
+
+.mode-toggle__btn {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 1rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: #6b7280;
+  transition: color 0.15s, background-color 0.15s, box-shadow 0.15s;
+
+  &:hover {
+    color: #374151;
+  }
+
+  &--active {
+    background-color: white;
+    box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.08);
+    color: #111827;
+  }
+}
+//Upload Zone
+.upload-zone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 1.5rem;
+  border: 2px dashed #e5e7eb;
+  border-radius: 0.75rem;
+  cursor: pointer;
+  background-color: #f9fafb;
+  transition: border-color 0.15s, background-color 0.15s;
+
+  &:hover {
+    border-color: #d1d5db;
+    background-color: #f3f4f6;
+  }
+
+  &--filled {
+    border-color: #93c5fd;
+    background-color: #eff6ff;
+  }
+}
+
+.upload-icon {
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  color: #9ca3af;
+
+  .upload-zone--filled & {
+    color: #60a5fa;
+  }
+}
+
+.upload-filename {
+  font-size: 0.875rem;
+  color: #9ca3af;
+
+  .upload-zone--filled & {
+    font-weight: 500;
+    color: #2563eb;
+  }
+}
+
+.upload-meta {
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+
+.upload-example {
+  margin-top: 0.75rem;
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+
+.upload-example__link {
+  color: #2563eb;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: inherit;
+  padding: 0;
+
+  &:hover {
+    color: #1d4ed8;
+  }
+}
+
+//Existing project select
+
+.existing-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+//Data preview
+
+.data-preview {
+  margin-top: 1.25rem;
+}
+
+.data-preview__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+.data-preview__label {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: #4b5563;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.data-preview__toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  color: #9ca3af;
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: color 0.15s;
+
+  &:hover {
+    color: #4b5563;
+  }
+}
+
+.data-preview__table-wrap {
+  border: 1px solid #f3f4f6;
+  border-radius: 0.5rem;
+  overflow-x: auto;
+  font-size: 0.75rem;
+}
+
+.data-preview__table {
+  min-width: 100%;
+  border-collapse: collapse;
+
+  thead {
+    background-color: #f9fafb;
+  }
+
+  th {
+    padding: 0.5rem 0.75rem;
+    text-align: left;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #6b7280;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    white-space: nowrap;
+    max-width: 160px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  tbody tr {
+    border-top: 1px solid #f9fafb;
+
+    &:hover {
+      background-color: #f9fafb;
+    }
+  }
+
+  td {
+    padding: 0.375rem 0.75rem;
+    color: #4b5563;
+    max-width: 160px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+//Column mapping
+
+.col-mapping {
+  border-top: 1px solid #f3f4f6;
+  padding-top: 2rem;
+}
+
+.col-mapping__title {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+  margin-bottom: 1rem;
+}
+
+.col-suggestions {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.col-suggestions__label {
+  font-size: 0.75rem;
+  color: #9ca3af;
+}
+
+.col-suggestion-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  background-color: #eff6ff;
+  color: #2563eb;
+  border: 1px solid #bfdbfe;
+  border-radius: 0.25rem;
+  padding: 0.125rem 0.5rem;
+  cursor: pointer;
+  transition: background-color 0.15s;
+
+  &:hover {
+    background-color: #dbeafe;
+  }
+}
+
+//Split sizes
+
+.split-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+}
+
+.split-slider {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.split-slider__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.split-slider__label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+}
+
+.split-slider__pct {
+  font-size: 0.75rem;
+  color: #9ca3af;
+}
+
+.split-slider__track {
+  position: relative;
+  height: 0.5rem;
+  border-radius: 9999px;
+  background-color: #f3f4f6;
+}
+
+.split-slider__fill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  border-radius: 9999px;
+  transition: width 0.15s;
+}
+
+.split-slider__range {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+
+  &:disabled {
+    cursor: not-allowed;
+  }
+}
+
+.split-slider__controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.split-slider__bound {
+  font-size: 0.75rem;
+  color: #9ca3af;
+}
+
+.split-total {
+  margin-top: 0.75rem;
+  font-size: 0.75rem;
+  color: #9ca3af;
+  text-align: right;
+}
+
+//Numeric stepper 
+
+.stepper {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.stepper__btn {
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 0.25rem;
+  border: 1px solid #e5e7eb;
+  background: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #6b7280;
+  cursor: pointer;
+  transition: background-color 0.15s;
+  flex-shrink: 0;
+
+  &:hover:not(:disabled) {
+    background-color: #f9fafb;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+}
+
+.stepper__input {
+  width: 5rem;
+  text-align: center;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  outline: none;
+
+  &:focus {
+    box-shadow: 0 0 0 1px #60a5fa;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+  }
+}
+
+//Strategy buttons
+
+.strategy-grid {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(2, 1fr);
+
+  @media (min-width: 640px) {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+.holdout-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.5rem;
+  width: 16rem;
+}
+
+.strategy-btn {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid #e5e7eb;
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-align: left;
+  background: white;
+  color: #4b5563;
+  cursor: pointer;
+  transition: border-color 0.15s, background-color 0.15s, color 0.15s;
+
+  &:hover:not(:disabled) {
+    border-color: #d1d5db;
+    background-color: #f9fafb;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+
+  &--active {
+    border-color: #60a5fa;
+    background-color: #eff6ff;
+    color: #1d4ed8;
+  }
+}
+
+//Sequential slice panel 
+
+.slice-panel {
+  margin-top: 1rem;
+  padding: 1rem;
+  border: 1px dashed #e5e7eb;
+  border-radius: 0.75rem;
+  background-color: #f9fafb;
+}
+
+.slice-panel__desc {
+  font-size: 0.75rem;
+  color: #6b7280;
+  margin-bottom: 1rem;
+}
+
+.slice-panel__grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.5rem;
+}
+
+.slice-item {
+  &--disabled {
+    opacity: 0.4;
+    pointer-events: none;
+  }
+}
+
+.slice-item__title {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: #4b5563;
+  margin-bottom: 0.75rem;
+}
+
+.slice-item__fields {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.slice-field__header {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: #9ca3af;
+  margin-bottom: 0.25rem;
+}
+
+.slice-field__range {
+  width: 100%;
+  accent-color: #3b82f6;
+}
+
+.slice-item__empty-hint {
+  font-size: 0.75rem;
+  color: #9ca3af;
+  margin-top: 0.5rem;
+}
+
+//Stratification picker (shared)
+
+.stratify-picker {
+  margin-top: 1rem;
+}
+
+.stratify-picker__label {
+  display: block;
+  font-size: 0.75rem;
+  color: #6b7280;
+  margin-bottom: 0.25rem;
+}
+
+//Drop annotations (test)
+
+.drop-annotations {
+  border-top: 1px solid #f3f4f6;
+  padding-top: 2rem;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: #4b5563;
+  cursor: pointer;
+
+  input[type='checkbox'] {
+    border-radius: 0.25rem;
+    border-color: #d1d5db;
+    accent-color: #3b82f6;
+    width: 1rem;
+    height: 1rem;
+    cursor: pointer;
+  }
+}
+
+//Advanced options
+
+.advanced-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: #6b7280;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  transition: color 0.15s;
+
+  &:hover {
+    color: #374151;
+  }
+}
+
+.advanced-panel {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.seed-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.875rem;
+  color: #4b5563;
+}
+
+.seed-input {
+  width: 6rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  outline: none;
+
+  &:focus {
+    box-shadow: 0 0 0 2px #60a5fa;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+  }
+}
+
+//Submit ─────────
+
+.submit-btn {
+  width: 100%;
+  background-color: #2563eb;
+  color: white;
+  font-weight: 500;
+  font-size: 0.875rem;
+  padding: 0.625rem 1rem;
+  border-radius: 0.5rem;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.15s;
+
+  &:hover:not(:disabled) {
+    background-color: #1d4ed8;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}

--- a/frontend/src/styles/_progress_bar.scss
+++ b/frontend/src/styles/_progress_bar.scss
@@ -53,3 +53,29 @@
         }
     }
 }
+//Loading Spinner
+.loading-state {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.3);
+  z-index: 9999;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.loading {
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  border: 10px solid #ddd;
+  border-top-color: orange;
+  animation: loading 1s linear infinite;
+}
+@keyframes loading {
+  to {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
refactor: improve project creation dataset splitting strategy

Also , related to dataset representativeness problem raised in Issue #934 :

Splitting is now organized around two clear axes which i consider it to be more flexible and controllable alternative  , So 

The 1st Axis: train selection strategy:
- random_selection: random draw from remaining data
- stratify_train: stratified split by column
- force_label: maximize labeled data in trainset
- deterministic: sequential when no random ``[0,n_train]

The 2nd Axis : HoldoutPool Selcetion(Test +Validation data):
-stratify_test: stratified draw for test/valid sets
-random selection 
- sequential/deterministic: supports custom start_index_val + start_index_test with overlap protection (train/valid/test overlap checks)

so for that i :
- refactored create_project task
- updated projectcreationform  and tried to improved UI/UX for better readability and aesthetics
- updated project parameters display
- updated styles for new form layout
- Made The example Dataset Ready To use by only one click 

NB:Now i remebred i didn't change the name of the example dataset 