### PR TITLE
[Faulty]

### DIFF
--- a/api/activetigger/project.py
+++ b/api/activetigger/project.py
@@ -533,10 +533,12 @@ class Project:
         if dataset == "test":
             df[["id_external", "text"]].to_parquet(self.params.dir.joinpath(config.test_file))
             self.params.test = True
+            self.params.n_test=len(df)
             self.data.load_dataset("test")
         elif dataset == "valid":
             df[["id_external", "text"]].to_parquet(self.params.dir.joinpath(config.valid_file))
             self.params.valid = True
+            self.params.n_valid=len(df)
             self.data.load_dataset("valid")
         else:
             raise Exception("Dataset should be test or valid")

--- a/api/activetigger/project.py
+++ b/api/activetigger/project.py
@@ -432,7 +432,9 @@ class Project:
         self.db_manager.projects_service.update_project(
             self.params.project_slug, jsonable_encoder(self.params)
         )
-
+        
+        #Added Load → getfullid refresh
+        self.data.load_dataset("all")
         # reset the features file
         self.features.reset_features_file()
         self.quickmodels.drop_models(which="all")
@@ -498,11 +500,22 @@ class Project:
             df["label"] = df["label"].apply(lambda x: str(x) if pd.notna(x) else None)
 
         # deal with non-unique id
-        # TODO : compare with the general dataset
         df["id_external"] = df["id"].apply(str)
         if not ((df["id"].astype(str).apply(slugify)).nunique() == len(df)):
             df["id"] = [str(i) for i in range(len(df))]
             print("ID not unique, changed to default id")
+        
+        #General Set Comparision
+        
+        #get full Ids
+        index_all=self.data.get_full_id()
+        #check for overlaps
+        overlapping_ids = set(df["id_external"]).intersection(set(index_all))
+        if overlapping_ids:
+            df.loc[df["id_external"].isin(overlapping_ids), "id"] = [
+                str(i)+'_'+str(i) for i in range(len(overlapping_ids))
+                ]
+            print(f"{len(overlapping_ids)} IDs in the eval set already exist in the main dataset") 
 
         # identify the dataset as imported and set the id
         df["id"] = df["id"].apply(lambda x: f"imported-{str(x)}")

--- a/frontend/src/components/forms/EvalSetsManagement.tsx
+++ b/frontend/src/components/forms/EvalSetsManagement.tsx
@@ -129,8 +129,14 @@ export const EvalSetsManagement: FC<EvalSetsManagementModel> = ({
                   <div>
                     Size of the dataset : <b>{data.data.length - 1}</b>
                   </div>
-                  {/* TODO: AXEL if too many rows, the page expands and it messes everything */}
                   <DataTable<Record<DataType['headers'][number], string | number>>
+                    customStyles={{responsiveWrapper: {
+                      style: {
+                              maxWidth: '600px',
+                              overflowX: 'auto',
+                            },
+                          },
+                        }}
                     columns={data.headers.map((h) => ({
                       name: h,
                       selector: (row) => row[h],
@@ -139,6 +145,8 @@ export const EvalSetsManagement: FC<EvalSetsManagementModel> = ({
                         return typeof v === 'bigint' ? Number(v) : v;
                       },
                       width: '200px',
+                      wrap:true,
+                      
                     }))}
                     data={
                       data.data.slice(0, 5) as Record<keyof DataType['headers'], string | number>[]

--- a/frontend/src/components/forms/EvalSetsManagement.tsx
+++ b/frontend/src/components/forms/EvalSetsManagement.tsx
@@ -146,7 +146,7 @@ export const EvalSetsManagement: FC<EvalSetsManagementModel> = ({
                       },
                       width: '200px',
                       wrap:true,
-                      
+        
                     }))}
                     data={
                       data.data.slice(0, 5) as Record<keyof DataType['headers'], string | number>[]


### PR DESCRIPTION
Fix react datatable overflow when importing files with many columns, while maintaining cell width at 200px 