### PR TITLE
Fix:datatable_overflow_evalsetmgmt

### DIFF
--- a/frontend/src/components/forms/EvalSetsManagement.tsx
+++ b/frontend/src/components/forms/EvalSetsManagement.tsx
@@ -129,8 +129,14 @@ export const EvalSetsManagement: FC<EvalSetsManagementModel> = ({
                   <div>
                     Size of the dataset : <b>{data.data.length - 1}</b>
                   </div>
-                  {/* TODO: AXEL if too many rows, the page expands and it messes everything */}
                   <DataTable<Record<DataType['headers'][number], string | number>>
+                    customStyles={{responsiveWrapper: {
+                      style: {
+                              maxWidth: '600px',
+                              overflowX: 'auto',
+                            },
+                          },
+                        }}
                     columns={data.headers.map((h) => ({
                       name: h,
                       selector: (row) => row[h],
@@ -139,6 +145,7 @@ export const EvalSetsManagement: FC<EvalSetsManagementModel> = ({
                         return typeof v === 'bigint' ? Number(v) : v;
                       },
                       width: '200px',
+                      wrap:true,
                     }))}
                     data={
                       data.data.slice(0, 5) as Record<keyof DataType['headers'], string | number>[]


### PR DESCRIPTION
Fix react dataTable overflow when importing files with many columns (maintained 200px cell width )