### PR TITLE
fix:condition for get_full_idx

### DIFF
--- a/api/activetigger/data.py
+++ b/api/activetigger/data.py
@@ -155,7 +155,7 @@ class Data:
         """
         Get the full list of IDs from the raw file
         """
-        if self.index is None:
+        if self.index.empty:
             self.index = pd.read_parquet(self.path_data_all, columns=["id_external"])
         return self.index
 


### PR DESCRIPTION
Fix the condition for the `get_full_id` in the `Data` class:

-if self.index is None: → if self.index.empty:

since index is already initialized a `pd.DataFrame()` 

Mentionned Previously Here #992 
