### PR TITLE
Improve:force label from all label columns

### DIFF
--- a/api/activetigger/tasks/create_project.py
+++ b/api/activetigger/tasks/create_project.py
@@ -230,7 +230,7 @@ class CreateProject(BaseTask):
             f_na =content[content[self.params.cols_label].isna().all(axis=1)]
             # different case regarding the number of labels
             if len(f_notna) > self.params.n_train:
-                trainset = content[f_notna].sample(
+                trainset =f_notna.sample(
                     self.params.n_train, random_state=self.random_seed
                 )
             else:

--- a/api/activetigger/tasks/create_project.py
+++ b/api/activetigger/tasks/create_project.py
@@ -224,7 +224,7 @@ class CreateProject(BaseTask):
             and self.params.n_valid == 0
         ):
             trainset = content[0 : self.params.n_train]
-        # case to force the max of label from one column
+        # case to force the max of label from all label columns
         elif self.params.force_label and len(self.params.cols_label) > 0:
             f_notna = content[content[self.params.cols_label].notna().any(axis=1)]
             f_na =content[content[self.params.cols_label].isna().all(axis=1)]

--- a/api/activetigger/tasks/create_project.py
+++ b/api/activetigger/tasks/create_project.py
@@ -226,19 +226,19 @@ class CreateProject(BaseTask):
             trainset = content[0 : self.params.n_train]
         # case to force the max of label from one column
         elif self.params.force_label and len(self.params.cols_label) > 0:
-            f_notna = content[self.params.cols_label[0]].notna()
-            f_na = content[self.params.cols_label[0]].isna()
+            f_notna = content[content[self.params.cols_label].notna().any(axis=1)]
+            f_na =content[content[self.params.cols_label].isna().all(axis=1)]
             # different case regarding the number of labels
-            if f_notna.sum() > self.params.n_train:
+            if len(f_notna) > self.params.n_train:
                 trainset = content[f_notna].sample(
                     self.params.n_train, random_state=self.random_seed
                 )
             else:
-                n_train_random = self.params.n_train - f_notna.sum()
+                n_train_random = self.params.n_train -len(f_notna)
                 trainset = pd.concat(
                     [
-                        content[f_notna],
-                        content[f_na].sample(n_train_random, random_state=self.random_seed),
+                        f_notna,
+                        f_na.sample(n_train_random, random_state=self.random_seed),
                     ]
                 )
         # case there is stratification on the trainset


### PR DESCRIPTION
Hello,

Following up on our previous discussion about refactoring project creation: we realized that only the first element of the label column is being selected during project creation, in fact Axel noted this and said we hadn't handled it properly in the orig implementation.
it is now posible to force the max of label from all label columns.