### PR TITLE
Fix: queue management

### DIFF
--- a/api/activetigger/orchestrator.py
+++ b/api/activetigger/orchestrator.py
@@ -168,7 +168,7 @@ class Orchestrator:
         Synchronous work for the update loop (runs in a thread to avoid
         blocking the async event loop).
         """
-        self.queue.clean_old_processes()
+        self.queue.clean_old_processes(timeout=4)
         timer = time.time()
 
         # loop on loaded projects

--- a/api/activetigger/queue_manager.py
+++ b/api/activetigger/queue_manager.py
@@ -104,7 +104,6 @@ class Queue:
         ):
             #self.executor = get_reusable_executor(max_workers=(self.nb_workers), timeout=600)
             task_cpu[0].future = self.executor.submit(task_cpu[0].task)
-            print(self.executor.executor_id)
             task_cpu[0].state = "running"
     
     async def _update_queue(self, timeout: float = 1) -> None:
@@ -162,6 +161,8 @@ class Queue:
         element = [i for i in self.current if i.unique_id == unique_id]
         if len(element) == 0:
             return None
+        if element[0].future and element[0].future.done():
+            element[0].state = "done"
         return element[0]
 
     def kill(self, unique_id: str) -> None:

--- a/api/activetigger/queue_manager.py
+++ b/api/activetigger/queue_manager.py
@@ -36,7 +36,7 @@ class Queue:
     current: list[QueueTaskModel]
     last_restart: datetime.datetime
 
-    def __init__(self, nb_workers_cpu: int = 3, nb_workers_gpu: int = 1) -> None:
+    def __init__(self, nb_workers_cpu: int = 5, nb_workers_gpu: int = 1) -> None:
         """
         Initiating the queue
         :param nb_workers_cpu: Number of CPU workers
@@ -92,7 +92,7 @@ class Queue:
             and (nb_active_processes_gpu + nb_active_processes_cpu) < self.nb_workers
             and len(task_gpu) > 0
         ):
-            self.executor = get_reusable_executor(max_workers=(self.nb_workers), timeout=600)
+            #self.executor = get_reusable_executor(max_workers=(self.nb_workers), timeout=600)
             task_gpu[0].future = self.executor.submit(task_gpu[0].task)
             task_gpu[0].state = "running"
 
@@ -102,19 +102,11 @@ class Queue:
             and (nb_active_processes_gpu + nb_active_processes_cpu) < self.nb_workers
             and len(task_cpu) > 0
         ):
-            self.executor = get_reusable_executor(max_workers=(self.nb_workers), timeout=600)
+            #self.executor = get_reusable_executor(max_workers=(self.nb_workers), timeout=600)
             task_cpu[0].future = self.executor.submit(task_cpu[0].task)
+            print(self.executor.executor_id)
             task_cpu[0].state = "running"
-
-        # if there is nothing in the queue, shutdown the executor to free GPU memory
-        # if (
-        #     nb_active_processes_cpu + nb_active_processes_gpu == 0
-        #     and len(task_gpu) == 0
-        #     and len(task_cpu) == 0
-        # ):
-        #     executor = get_reusable_executor(max_workers=(self.nb_workers), timeout=600)
-        #     executor.shutdown(wait=False)
-
+    
     async def _update_queue(self, timeout: float = 1) -> None:
         """
         Update the queue every X seconds.
@@ -179,8 +171,8 @@ class Queue:
         element = [i for i in self.current if i.unique_id == unique_id]
         if len(element) == 0:
             raise Exception("Process not found")
-        element[0].event.set()  # TODO update status to flag the killing
-        self.delete(unique_id)  # TODO move this to the cleaning method
+        element[0].event.set()
+        element[0].state="cancelled"
 
     def delete(self, ids: str | list) -> None:
         """
@@ -189,8 +181,8 @@ class Queue:
         if isinstance(ids, str):
             ids = [ids]
         for i in [t for t in self.current if t.unique_id in ids]:
-            if i.future is None or not i.future.done():
-                print("Deleting a unfinished process")
+            if i.state=="cancelled":
+                print("Deleting a unfinished process",flush=True)
             self.current.remove(i)
 
     def state(self) -> list[QueueStateTaskModel]:
@@ -228,17 +220,24 @@ class Queue:
         )
         return None
 
-    def clean_old_processes(self, timeout: int = 2) -> None:
+    def clean_old_processes(self, timeout: int =2) -> None:
         """
         Remove old processes
         """
         n = len(self.current)
-        self.current = [
-            i
+        terminal={"done","cancelled"}
+        old_processes_ids= [
+            i.unique_id
             for i in self.current
-            if (datetime.datetime.now(timezone.utc) - i.starting_time).total_seconds() / 3600
-            < timeout
+            if i.state in terminal
+            or(
+            # if task life duration in the queue is more than timeout and it's not pending or running
+            (datetime.datetime.now(timezone.utc) - i.starting_time).total_seconds() / 3600 >= timeout
+            and i.state not in {"pending", "running"}
+            )
         ]
+        if len(old_processes_ids)>0:
+            self.delete(old_processes_ids)
         if n != len(self.current):
             print(f"Cleaned {n - len(self.current)} processes")
         return None
@@ -250,3 +249,4 @@ class Queue:
         executor = get_reusable_executor(max_workers=(self.nb_workers), timeout=600)
         executor.shutdown(wait=False)
         self.current = []
+        

--- a/api/activetigger/tasks/add_evalset.py
+++ b/api/activetigger/tasks/add_evalset.py
@@ -62,7 +62,7 @@ class AddEvalSet(BaseTask):
             # added a check if DF is empty to avoid errors
             if len(df) == 0:
                 raise Exception("Your valid set is empty")
-            print("df cols", df.columns, flush=True)
+            #print("df cols", df.columns, flush=True)
             # stop Process
             self.__stop_process_opportunity()
             # create text column


### PR DESCRIPTION
kill() to mark state as cancelled instead of immediately deleting from queue
Fixed clean_old_processes to also remove terminal state tasks (done, cancelled)

-  Removed get_reusable_executor calls inside _dispatch_pending_tasks so it is initialized once
- added state "cancelled" to mark cancelled tasks in `kill()`
- moved delete to clean_old_processes()
NB (kept the direct call for delete func in the project class)

you can see that memory and cpu usages dropped significantly 
